### PR TITLE
Add liquid glass messenger UI shell

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 dependencies {
     implementation(project(":designsystem"))
     implementation(project(":features:chatlist"))
+    implementation(project(":features:timeline"))
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)

--- a/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
@@ -3,14 +3,62 @@ package com.shadowchat.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.shadowchat.designsystem.ShadowChatTheme
+import com.shadowchat.designsystem.ShadowColors
+import com.shadowchat.designsystem.ShadowGlassPanel
+import com.shadowchat.designsystem.ShadowLiquidBackground
+import com.shadowchat.designsystem.ShadowRadii
+import com.shadowchat.designsystem.ShadowSpacing
+import com.shadowchat.designsystem.shadowAccentGradient
 import com.shadowchat.features.chatlist.ChatListItemUi
 import com.shadowchat.features.chatlist.ChatListRepository
 import com.shadowchat.features.chatlist.ChatListRoute
+import com.shadowchat.features.chatlist.ChatListTrustLevel
 import com.shadowchat.features.chatlist.ChatListViewModel
+import com.shadowchat.features.timeline.RoomTimelineDeliveryState
+import com.shadowchat.features.timeline.RoomTimelineItemUi
+import com.shadowchat.features.timeline.RoomTimelineMessageDirection
+import com.shadowchat.features.timeline.RoomTimelineRepository
+import com.shadowchat.features.timeline.RoomTimelineRoute
+import com.shadowchat.features.timeline.RoomTimelineSnapshotUi
+import com.shadowchat.features.timeline.RoomTimelineViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,20 +67,301 @@ class MainActivity : ComponentActivity() {
         setContent {
             ShadowChatTheme {
                 val chatListViewModel: ChatListViewModel = viewModel(
-                    factory = ChatListViewModelFactory(EmptyChatListRepository),
+                    factory = ChatListViewModelFactory(DemoChatListRepository),
                 )
 
-                ChatListRoute(
-                    viewModel = chatListViewModel,
-                    onRoomSelected = {},
-                )
+                ShadowChatAppShell(chatListViewModel = chatListViewModel)
             }
         }
     }
 }
 
-private object EmptyChatListRepository : ChatListRepository {
-    override suspend fun loadChatList(): List<ChatListItemUi> = emptyList()
+@Composable
+private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
+    var selectedTab by remember { mutableStateOf(AppTab.Chats) }
+    var selectedRoomId by remember { mutableStateOf<String?>(null) }
+
+    ShadowLiquidBackground(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = Color.Transparent,
+            bottomBar = {
+                ShadowBottomBar(
+                    selectedTab = selectedTab,
+                    onTabSelected = {
+                        selectedTab = it
+                        selectedRoomId = null
+                    },
+                )
+            },
+        ) { contentPadding ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding),
+            ) {
+                when (selectedTab) {
+                    AppTab.Chats -> {
+                        val roomId = selectedRoomId
+                        if (roomId == null) {
+                            ChatListRoute(
+                                viewModel = chatListViewModel,
+                                onRoomSelected = { selectedRoomId = it },
+                            )
+                        } else {
+                            val timelineViewModel: RoomTimelineViewModel = viewModel(
+                                key = roomId,
+                                factory = RoomTimelineViewModelFactory(
+                                    roomId = roomId,
+                                    repository = DemoRoomTimelineRepository,
+                                ),
+                            )
+
+                            Column {
+                                Button(
+                                    onClick = { selectedRoomId = null },
+                                    modifier = Modifier.padding(start = ShadowSpacing.Lg, top = ShadowSpacing.Lg),
+                                ) {
+                                    Text(text = stringResource(R.string.timeline_back_to_chats))
+                                }
+                                RoomTimelineRoute(viewModel = timelineViewModel)
+                            }
+                        }
+                    }
+                    AppTab.Calls -> CallsShell()
+                    AppTab.Updates -> UpdatesShell()
+                    AppTab.Profile -> ProfileShell()
+                    AppTab.Settings -> SettingsShell()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShadowBottomBar(
+    selectedTab: AppTab,
+    onTabSelected: (AppTab) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = ShadowSpacing.Lg, vertical = ShadowSpacing.Md),
+    ) {
+        ShadowGlassPanel(radius = ShadowRadii.Panel) {
+            NavigationBar(
+                containerColor = Color.Transparent,
+                tonalElevation = ShadowSpacing.Xs,
+            ) {
+                AppTab.entries.forEach { tab ->
+                    NavigationBarItem(
+                        selected = selectedTab == tab,
+                        onClick = { onTabSelected(tab) },
+                        icon = {
+                            Text(
+                                text = stringResource(tab.symbolResId),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                        },
+                        label = { Text(text = stringResource(tab.labelResId)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CallsShell() {
+    ShellScaffold(title = stringResource(R.string.tab_calls), symbol = stringResource(R.string.tab_calls_symbol)) {
+        PillRow(listOf("All", "Missed", "Voicemail"))
+        ShellRow("Sofia Martin", "Outgoing call, today", "Call")
+        ShellRow("Daniel Carter", "Missed call, yesterday", "Call")
+        ShellRow("Adventure Club", "Group call preview", "Call")
+    }
+}
+
+@Composable
+private fun UpdatesShell() {
+    ShellScaffold(title = stringResource(R.string.tab_updates), symbol = stringResource(R.string.tab_updates_symbol)) {
+        ShellRow("My Status", "Add a soft glass status update", "New")
+        ShellRow("Emma Wilson", "Recent update", "View")
+        ShellRow("Family", "Viewed update", "View")
+    }
+}
+
+@Composable
+private fun ProfileShell() {
+    ShellScaffold(title = stringResource(R.string.tab_profile), symbol = stringResource(R.string.tab_profile_symbol)) {
+        AvatarHero("Sofia Martin", "Online now")
+        PillRow(listOf("Message", "Call", "Video", "Pay"))
+        ShellRow("About", "Building calm, secure conversations.", "Edit")
+        ShellRow("Media, Links, Docs", "24 shared items", "Open")
+        ShellRow("Starred Messages", "Quick access shell", "Open")
+    }
+}
+
+@Composable
+private fun SettingsShell() {
+    ShellScaffold(title = stringResource(R.string.tab_settings), symbol = stringResource(R.string.tab_settings_symbol)) {
+        AvatarHero("ShadowChat", "Premium messenger shell")
+        listOf(
+            "Account",
+            "Privacy",
+            "Notifications",
+            "Appearance",
+            "Chats",
+            "Storage and Data",
+            "Help Center",
+            "Invite Friends",
+        ).forEach { title ->
+            ShellRow(title, "Settings group shell", "Open")
+        }
+    }
+}
+
+@Composable
+private fun ShellScaffold(
+    title: String,
+    symbol: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(ShadowSpacing.Lg),
+        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = symbol,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier
+                    .background(shadowAccentGradient(), CircleShape)
+                    .padding(ShadowSpacing.Md),
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+
+        content()
+    }
+}
+
+@Composable
+private fun PillRow(labels: List<String>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm)) {
+        labels.forEach { label ->
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier
+                    .background(ShadowColors.GlassSurface, CircleShape)
+                    .padding(horizontal = ShadowSpacing.Md, vertical = ShadowSpacing.Sm),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvatarHero(name: String, subtitle: String) {
+    ShadowGlassPanel(radius = ShadowRadii.Panel) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(ShadowSpacing.Lg),
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DemoAvatar(initial = name.first().toString())
+            Column {
+                Text(text = name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(text = subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShellRow(title: String, subtitle: String, trailing: String) {
+    ShadowGlassPanel(
+        modifier = Modifier.fillMaxWidth(),
+        radius = ShadowRadii.Card,
+    ) {
+        Row(
+            modifier = Modifier.padding(ShadowSpacing.Md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DemoAvatar(initial = title.first().toString())
+            Spacer(modifier = Modifier.width(ShadowSpacing.Md))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Text(text = trailing, style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+@Composable
+private fun DemoAvatar(initial: String) {
+    Box(
+        modifier = Modifier
+            .size(52.dp)
+            .background(shadowAccentGradient(), CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = initial, color = Color.White, fontWeight = FontWeight.Bold)
+    }
+}
+
+private enum class AppTab(
+    val labelResId: Int,
+    val symbolResId: Int,
+) {
+    Chats(R.string.tab_chats, R.string.tab_chats_symbol),
+    Calls(R.string.tab_calls, R.string.tab_calls_symbol),
+    Updates(R.string.tab_updates, R.string.tab_updates_symbol),
+    Profile(R.string.tab_profile, R.string.tab_profile_symbol),
+    Settings(R.string.tab_settings, R.string.tab_settings_symbol),
+}
+
+private object DemoChatListRepository : ChatListRepository {
+    override suspend fun loadChatList(): List<ChatListItemUi> = listOf(
+        ChatListItemUi("sofia", "Sofia Martin", "Hey! Are we still on for dinner tonight?", "09:41", 2, ChatListTrustLevel.Verified, true),
+        ChatListItemUi("design-squad", "Design Squad", "Liam: I will share the assets here.", "09:12", 8, ChatListTrustLevel.Standard, true),
+        ChatListItemUi("jason", "Jason Lee", "Sounds good, talk soon!", "Yesterday", 0, ChatListTrustLevel.Verified),
+        ChatListItemUi("family", "Family", "Mom: Do not forget Sunday lunch at grandma's!", "Sun", 4, ChatListTrustLevel.Standard),
+        ChatListItemUi("emma", "Emma Wilson", "Looks amazing!", "Sat", 1, ChatListTrustLevel.Verified),
+        ChatListItemUi("adventure", "Adventure Club", "Trail photos are ready.", "Fri", 0, ChatListTrustLevel.Reduced),
+        ChatListItemUi("noah", "Noah Johnson", "Can you review this later?", "Thu", 0, ChatListTrustLevel.Standard),
+        ChatListItemUi("daniel", "Daniel Carter", "Call me when you are free.", "Wed", 3, ChatListTrustLevel.Reduced),
+    )
+}
+
+private object DemoRoomTimelineRepository : RoomTimelineRepository {
+    override suspend fun loadTimeline(roomId: String): RoomTimelineSnapshotUi {
+        val title = DemoChatListRepository.loadChatList().firstOrNull { it.roomId == roomId }?.title ?: "Conversation"
+        return RoomTimelineSnapshotUi(
+            roomId = roomId,
+            roomTitle = title,
+            items = listOf(
+                RoomTimelineItemUi("m1", title, "Hey! Are we still on for dinner tonight?", "09:41", RoomTimelineMessageDirection.Incoming, RoomTimelineDeliveryState.Read),
+                RoomTimelineItemUi("m2", null, "Yes. I will be there at 8.", "09:43", RoomTimelineMessageDirection.Outgoing, RoomTimelineDeliveryState.Delivered),
+                RoomTimelineItemUi("m3", title, "Perfect. I saved us a table near the window.", "09:44", RoomTimelineMessageDirection.Incoming, RoomTimelineDeliveryState.Read),
+                RoomTimelineItemUi("m4", null, "Voice preview and media cards will land in the send pipeline slice.", "09:45", RoomTimelineMessageDirection.Outgoing, RoomTimelineDeliveryState.Sent),
+            ),
+        )
+    }
 }
 
 private class ChatListViewModelFactory(
@@ -45,5 +374,19 @@ private class ChatListViewModelFactory(
         }
 
         return ChatListViewModel(repository) as T
+    }
+}
+
+private class RoomTimelineViewModelFactory(
+    private val roomId: String,
+    private val repository: RoomTimelineRepository,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass == RoomTimelineViewModel::class.java) {
+            "Unsupported ViewModel: ${modelClass.name}"
+        }
+
+        return RoomTimelineViewModel(roomId, repository) as T
     }
 }

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,19 @@
 <resources>
     <string name="app_name">ShadowChat</string>
+    <string name="tab_chats">Chats</string>
+    <string name="tab_calls">Calls</string>
+    <string name="tab_updates">Updates</string>
+    <string name="tab_profile">Profile</string>
+    <string name="tab_settings">Settings</string>
+    <string name="tab_chats_symbol">Chat</string>
+    <string name="tab_calls_symbol">Call</string>
+    <string name="tab_updates_symbol">News</string>
+    <string name="tab_profile_symbol">Me</string>
+    <string name="tab_settings_symbol">Gear</string>
+    <string name="timeline_back_to_chats">Chats</string>
+    <string name="tab_chats_body">Your conversations stay on the main screen.</string>
+    <string name="tab_calls_body">Call surfaces will live here once the calls slice is implemented.</string>
+    <string name="tab_updates_body">Updates will live here once the updates slice is implemented.</string>
+    <string name="tab_profile_body">Profile controls will live here once the profile slice is implemented.</string>
+    <string name="tab_settings_body">App settings will live here once the settings slice is implemented.</string>
 </resources>

--- a/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowChatTheme.kt
+++ b/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowChatTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun ShadowChatTheme(
@@ -19,8 +20,30 @@ fun ShadowChatTheme(
 
 private val LightColorScheme = lightColorScheme(
     primary = ShadowColors.UnreadBadge,
+    onPrimary = Color.White,
+    primaryContainer = ShadowColors.OutgoingBubble,
+    onPrimaryContainer = ShadowColors.DeepText,
+    secondaryContainer = ShadowColors.IceBlue,
+    onSecondaryContainer = ShadowColors.DeepText,
+    background = ShadowColors.Porcelain,
+    onBackground = ShadowColors.DeepText,
+    surface = ShadowColors.GlassSurface,
+    onSurface = ShadowColors.DeepText,
+    surfaceVariant = ShadowColors.IncomingBubble,
+    onSurfaceVariant = ShadowColors.SoftText,
 )
 
 private val DarkColorScheme = darkColorScheme(
     primary = ShadowColors.UnreadBadge,
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFF2B2443),
+    onPrimaryContainer = Color(0xFFF7F1FF),
+    secondaryContainer = Color(0xFF1F3044),
+    onSecondaryContainer = Color(0xFFEAF5FF),
+    background = Color(0xFF11101A),
+    onBackground = Color(0xFFF7F1FF),
+    surface = Color(0xE61D1A2A),
+    onSurface = Color(0xFFF7F1FF),
+    surfaceVariant = Color(0xFF252233),
+    onSurfaceVariant = Color(0xFFC9C1D9),
 )

--- a/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowColors.kt
+++ b/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowColors.kt
@@ -9,10 +9,22 @@ enum class ShadowTrustTone {
 }
 
 object ShadowColors {
-    val VerifiedTrust = Color(0xFF2EAD6B)
-    val StandardTrust = Color(0xFF8A8D93)
-    val ReducedTrust = Color(0xFFC77700)
-    val UnreadBadge = Color(0xFF2B6DFF)
+    val Porcelain = Color(0xFFFFFBFF)
+    val LavenderMist = Color(0xFFF3EEFF)
+    val IceBlue = Color(0xFFEAF5FF)
+    val Blush = Color(0xFFFFEEF7)
+    val GlassSurface = Color(0xEFFFFFFF)
+    val GlassStroke = Color(0x99FFFFFF)
+    val DeepText = Color(0xFF191327)
+    val SoftText = Color(0xFF6E6680)
+    val AccentStart = Color(0xFF7B61FF)
+    val AccentEnd = Color(0xFF39A7FF)
+    val VerifiedTrust = Color(0xFF22B573)
+    val StandardTrust = Color(0xFF918AA5)
+    val ReducedTrust = Color(0xFFFF9F2E)
+    val UnreadBadge = Color(0xFF6757FF)
+    val IncomingBubble = Color(0xF7FFFFFF)
+    val OutgoingBubble = Color(0xFFEDE7FF)
 
     fun trustColor(tone: ShadowTrustTone): Color = when (tone) {
         ShadowTrustTone.Verified -> VerifiedTrust

--- a/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowLiquidGlass.kt
+++ b/apps/android/designsystem/src/main/java/com/shadowchat/designsystem/ShadowLiquidGlass.kt
@@ -1,0 +1,80 @@
+package com.shadowchat.designsystem
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object ShadowRadii {
+    val Panel = 32.dp
+    val Card = 26.dp
+    val Bubble = 24.dp
+    val Control = 22.dp
+}
+
+@Composable
+fun ShadowLiquidBackground(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val colors = if (isSystemInDarkTheme()) {
+        listOf(
+            Color(0xFF11101A),
+            Color(0xFF1C1830),
+            Color(0xFF132437),
+            Color(0xFF241829),
+        )
+    } else {
+        listOf(
+            ShadowColors.Porcelain,
+            ShadowColors.LavenderMist,
+            ShadowColors.IceBlue,
+            ShadowColors.Blush,
+        )
+    }
+
+    Box(
+        modifier = modifier.background(
+            Brush.linearGradient(
+                colors = colors,
+            ),
+        ),
+        content = content,
+    )
+}
+
+@Composable
+fun ShadowGlassPanel(
+    modifier: Modifier = Modifier,
+    radius: Dp = ShadowRadii.Panel,
+    content: @Composable () -> Unit,
+) {
+    val darkTheme = isSystemInDarkTheme()
+
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(radius),
+        color = if (darkTheme) Color(0xCC1D1A2A) else ShadowColors.GlassSurface,
+        contentColor = if (darkTheme) Color(0xFFF7F1FF) else ShadowColors.DeepText,
+        border = BorderStroke(1.dp, if (darkTheme) Color(0x33FFFFFF) else ShadowColors.GlassStroke),
+        shadowElevation = 14.dp,
+        tonalElevation = 0.dp,
+        content = content,
+    )
+}
+
+fun shadowAccentGradient(): Brush = Brush.horizontalGradient(
+    colors = listOf(
+        ShadowColors.AccentStart,
+        ShadowColors.AccentEnd,
+    ),
+)

--- a/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListModels.kt
+++ b/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListModels.kt
@@ -5,8 +5,11 @@ import com.shadowchat.designsystem.ShadowTrustTone
 data class ChatListItemUi(
     val roomId: String,
     val title: String,
+    val previewText: String = "",
+    val sentAtLabel: String = "",
     val unreadCount: Int,
     val trustLevel: ChatListTrustLevel,
+    val isFavorite: Boolean = false,
 )
 
 enum class ChatListTrustLevel {

--- a/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListScreen.kt
+++ b/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListScreen.kt
@@ -12,19 +12,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -33,7 +35,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.shadowchat.designsystem.ShadowColors
+import com.shadowchat.designsystem.ShadowGlassPanel
+import com.shadowchat.designsystem.ShadowLiquidBackground
+import com.shadowchat.designsystem.ShadowRadii
 import com.shadowchat.designsystem.ShadowSpacing
+import com.shadowchat.designsystem.shadowAccentGradient
 
 @Composable
 fun ChatListScreen(
@@ -41,20 +47,17 @@ fun ChatListScreen(
     onEvent: (ChatListEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    ShadowLiquidBackground(
         modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = ShadowSpacing.Lg),
+                .padding(horizontal = ShadowSpacing.Lg)
+                .padding(top = ShadowSpacing.Xl),
+            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
         ) {
-            Text(
-                text = stringResource(R.string.chat_list_title),
-                style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.padding(top = ShadowSpacing.Xl, bottom = ShadowSpacing.Md),
-            )
+            ChatListHeader()
 
             when (state) {
                 ChatListUiState.Loading -> ChatListLoadingState()
@@ -70,13 +73,89 @@ fun ChatListScreen(
 }
 
 @Composable
+private fun ChatListHeader() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Xs)) {
+                Text(
+                    text = stringResource(R.string.chat_list_title),
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = stringResource(R.string.chat_list_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(shadowAccentGradient()),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.chat_list_compose_symbol),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+        ) {
+            OutlinedTextField(
+                value = "",
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                placeholder = { Text(stringResource(R.string.chat_list_search_placeholder)) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+        ) {
+            AssistChip(
+                onClick = {},
+                label = { Text(stringResource(R.string.chat_list_filter_all)) },
+            )
+            AssistChip(
+                onClick = {},
+                label = { Text(stringResource(R.string.chat_list_filter_unread)) },
+            )
+            AssistChip(
+                onClick = {},
+                label = { Text(stringResource(R.string.chat_list_filter_groups)) },
+            )
+            AssistChip(
+                onClick = {},
+                label = { Text(stringResource(R.string.chat_list_filter_favorites)) },
+            )
+        }
+    }
+}
+
+@Composable
 private fun ChatListLoadedState(
     items: List<ChatListItemUi>,
     onEvent: (ChatListEvent) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Xs),
+        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
     ) {
         items(
             items = items,
@@ -97,30 +176,84 @@ private fun ChatListRow(
 ) {
     val label = chatListItemAccessibilityLabel(item)
 
-    Row(
+    ShadowGlassPanel(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
             .clickable(onClick = onClick)
-            .semantics { contentDescription = label }
-            .padding(vertical = ShadowSpacing.Md, horizontal = ShadowSpacing.Sm),
-        verticalAlignment = Alignment.CenterVertically,
+            .semantics { contentDescription = label },
+        radius = ShadowRadii.Card,
     ) {
-        TrustIndicator(trustLevel = item.trustLevel)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = ShadowSpacing.Md, horizontal = ShadowSpacing.Md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AvatarBadge(title = item.title)
 
-        Spacer(modifier = Modifier.width(ShadowSpacing.Md))
+            Spacer(modifier = Modifier.width(ShadowSpacing.Md))
 
-        Text(
-            text = item.title,
-            style = MaterialTheme.typography.titleMedium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Xs),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    TrustIndicator(trustLevel = item.trustLevel)
+                }
+                Text(
+                    text = item.previewText.ifBlank { trustPreviewLine(item.trustLevel) },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
 
-        if (item.unreadCount > 0) {
-            UnreadBadge(unreadCount = item.unreadCount)
+            if (item.sentAtLabel.isNotBlank()) {
+                Text(
+                    text = item.sentAtLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(end = ShadowSpacing.Xs),
+                )
+            }
+
+            if (item.unreadCount > 0) {
+                UnreadBadge(unreadCount = item.unreadCount)
+            }
         }
+    }
+}
+
+@Composable
+private fun AvatarBadge(title: String) {
+    val initial = title.firstOrNull()?.uppercaseChar()?.toString().orEmpty()
+
+    Box(
+        modifier = Modifier
+            .size(54.dp)
+            .clip(CircleShape)
+            .background(shadowAccentGradient()),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = initial,
+            style = MaterialTheme.typography.titleLarge,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 
@@ -128,7 +261,7 @@ private fun ChatListRow(
 private fun TrustIndicator(trustLevel: ChatListTrustLevel) {
     Box(
         modifier = Modifier
-            .size(24.dp)
+            .size(18.dp)
             .background(
                 color = ShadowColors.trustColor(trustLevel.toDesignTone()),
                 shape = CircleShape,
@@ -151,7 +284,7 @@ private fun UnreadBadge(unreadCount: Int) {
     Box(
         modifier = Modifier
             .padding(start = ShadowSpacing.Md)
-            .background(ShadowColors.UnreadBadge, CircleShape)
+            .background(shadowAccentGradient(), CircleShape)
             .padding(horizontal = ShadowSpacing.Sm, vertical = ShadowSpacing.Xs),
         contentAlignment = Alignment.Center,
     ) {
@@ -172,11 +305,15 @@ private fun ChatListLoadingState() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator(
-            modifier = Modifier.semantics {
-                contentDescription = loadingLabel
-            },
-        )
+        ShadowGlassPanel(radius = ShadowRadii.Panel) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .padding(ShadowSpacing.Xl)
+                    .semantics {
+                        contentDescription = loadingLabel
+                    },
+            )
+        }
     }
 }
 
@@ -186,24 +323,32 @@ private fun ChatListEmptyState() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+        ShadowGlassPanel(
+            modifier = Modifier.widthIn(max = 360.dp),
+            radius = ShadowRadii.Panel,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape),
-            )
-            Text(
-                text = stringResource(R.string.chat_list_empty_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = stringResource(R.string.chat_list_empty_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(
+                modifier = Modifier.padding(ShadowSpacing.Xl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(shadowAccentGradient(), CircleShape),
+                )
+                Text(
+                    text = stringResource(R.string.chat_list_empty_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(R.string.chat_list_empty_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -214,37 +359,45 @@ private fun ChatListErrorState(onEvent: (ChatListEvent) -> Unit) {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+        ShadowGlassPanel(
+            modifier = Modifier.widthIn(max = 360.dp),
+            radius = ShadowRadii.Panel,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .background(MaterialTheme.colorScheme.errorContainer, CircleShape),
-                contentAlignment = Alignment.Center,
+            Column(
+                modifier = Modifier.padding(ShadowSpacing.Xl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
             ) {
                 Text(
                     text = "!",
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    style = MaterialTheme.typography.titleMedium,
+                    color = ShadowColors.ReducedTrust,
+                    style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
                 )
-            }
-            Text(
-                text = stringResource(R.string.chat_list_error_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = stringResource(R.string.chat_list_error_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Button(onClick = { onEvent(ChatListEvent.RetryRequested) }) {
-                Text(text = stringResource(R.string.chat_list_retry))
+                Text(
+                    text = stringResource(R.string.chat_list_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(R.string.chat_list_error_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(onClick = { onEvent(ChatListEvent.RetryRequested) }) {
+                    Text(text = stringResource(R.string.chat_list_retry))
+                }
             }
         }
     }
+}
+
+@Composable
+private fun trustPreviewLine(trustLevel: ChatListTrustLevel): String = when (trustLevel) {
+    ChatListTrustLevel.Verified -> stringResource(R.string.chat_list_preview_verified)
+    ChatListTrustLevel.Standard -> stringResource(R.string.chat_list_preview_standard)
+    ChatListTrustLevel.Reduced -> stringResource(R.string.chat_list_preview_reduced)
 }
 
 @Composable

--- a/apps/android/features/chatlist/src/main/res/values/strings.xml
+++ b/apps/android/features/chatlist/src/main/res/values/strings.xml
@@ -1,5 +1,12 @@
 <resources>
     <string name="chat_list_title">Chats</string>
+    <string name="chat_list_subtitle">Private rooms, soft signals, clear trust.</string>
+    <string name="chat_list_compose_symbol">+</string>
+    <string name="chat_list_search_placeholder">Search conversations</string>
+    <string name="chat_list_filter_all">All</string>
+    <string name="chat_list_filter_unread">Unread</string>
+    <string name="chat_list_filter_groups">Groups</string>
+    <string name="chat_list_filter_favorites">Favorites</string>
     <string name="chat_list_loading">Loading chats</string>
     <string name="chat_list_empty_title">No chats yet</string>
     <string name="chat_list_empty_body">New conversations will appear here.</string>
@@ -15,4 +22,7 @@
     <string name="chat_list_trust_verified">verified trust</string>
     <string name="chat_list_trust_standard">standard trust</string>
     <string name="chat_list_trust_reduced">reduced trust</string>
+    <string name="chat_list_preview_verified">Verified secure conversation</string>
+    <string name="chat_list_preview_standard">Standard private conversation</string>
+    <string name="chat_list_preview_reduced">Reduced trust context</string>
 </resources>

--- a/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineScreen.kt
+++ b/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,7 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,7 +27,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.shadowchat.designsystem.ShadowColors
+import com.shadowchat.designsystem.ShadowGlassPanel
+import com.shadowchat.designsystem.ShadowLiquidBackground
+import com.shadowchat.designsystem.ShadowRadii
 import com.shadowchat.designsystem.ShadowSpacing
+import com.shadowchat.designsystem.shadowAccentGradient
 
 @Composable
 fun RoomTimelineScreen(
@@ -35,22 +40,17 @@ fun RoomTimelineScreen(
     onEvent: (RoomTimelineEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    ShadowLiquidBackground(
         modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = ShadowSpacing.Lg),
+                .padding(horizontal = ShadowSpacing.Lg)
+                .padding(top = ShadowSpacing.Xl),
+            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
         ) {
-            Text(
-                text = timelineTitle(state),
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = ShadowSpacing.Xl, bottom = ShadowSpacing.Md),
-            )
+            TimelineHeader(title = timelineTitle(state))
 
             when (state) {
                 RoomTimelineUiState.Loading -> RoomTimelineLoadingState()
@@ -58,6 +58,65 @@ fun RoomTimelineScreen(
                 is RoomTimelineUiState.Empty -> RoomTimelineEmptyState()
                 RoomTimelineUiState.Error -> RoomTimelineErrorState(onEvent = onEvent)
             }
+
+            if (state is RoomTimelineUiState.Loaded) {
+                TimelineComposer()
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineHeader(title: String) {
+    ShadowGlassPanel(radius = ShadowRadii.Panel) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(ShadowSpacing.Md),
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(shadowAccentGradient())
+                    .padding(horizontal = ShadowSpacing.Md, vertical = ShadowSpacing.Sm),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.room_timeline_room_symbol),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(R.string.room_timeline_shell_label),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                text = stringResource(R.string.room_timeline_call_action),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringResource(R.string.room_timeline_video_action),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }
@@ -71,11 +130,27 @@ private fun timelineTitle(state: RoomTimelineUiState): String = when (state) {
 }
 
 @Composable
-private fun RoomTimelineLoadedState(items: List<RoomTimelineItemUi>) {
+private fun ColumnScope.RoomTimelineLoadedState(items: List<RoomTimelineItemUi>) {
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
     ) {
+        item {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.room_timeline_day_today),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .background(ShadowColors.GlassSurface, RoundedCornerShape(20.dp))
+                        .padding(horizontal = ShadowSpacing.Md, vertical = ShadowSpacing.Xs),
+                )
+            }
+        }
+
         items(
             items = items,
             key = { item -> item.messageId },
@@ -105,23 +180,23 @@ private fun MessageBubble(item: RoomTimelineItemUi) {
     val isOutgoing = item.direction == RoomTimelineMessageDirection.Outgoing
     val accessibilityLabel = messageAccessibilityLabel(item)
     val bubbleColor = if (isOutgoing) {
-        MaterialTheme.colorScheme.primaryContainer
+        ShadowColors.OutgoingBubble
     } else {
-        MaterialTheme.colorScheme.surfaceVariant
+        ShadowColors.IncomingBubble
     }
     val contentColor = if (isOutgoing) {
-        MaterialTheme.colorScheme.onPrimaryContainer
+        MaterialTheme.colorScheme.onSurface
     } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
+        MaterialTheme.colorScheme.onSurface
     }
 
     Column(
         modifier = Modifier
             .widthIn(max = 320.dp)
-            .clip(RoundedCornerShape(18.dp))
+            .clip(RoundedCornerShape(ShadowRadii.Bubble))
             .background(bubbleColor)
             .semantics { contentDescription = accessibilityLabel }
-            .padding(horizontal = ShadowSpacing.Md, vertical = ShadowSpacing.Sm),
+            .padding(horizontal = ShadowSpacing.Lg, vertical = ShadowSpacing.Md),
         verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Xs),
     ) {
         if (!isOutgoing && item.senderDisplayName != null) {
@@ -133,9 +208,9 @@ private fun MessageBubble(item: RoomTimelineItemUi) {
             )
         }
         Text(
-            text = item.body,
-            style = MaterialTheme.typography.bodyLarge,
-            color = contentColor,
+                text = item.body,
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor,
         )
         Row(
             horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Xs),
@@ -144,12 +219,12 @@ private fun MessageBubble(item: RoomTimelineItemUi) {
             Text(
                 text = item.sentAtLabel,
                 style = MaterialTheme.typography.labelSmall,
-                color = contentColor.copy(alpha = 0.74f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
                 text = deliveryStateLabel(item.deliveryState),
                 style = MaterialTheme.typography.labelSmall,
-                color = contentColor.copy(alpha = 0.74f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -163,11 +238,39 @@ private fun RoomTimelineLoadingState() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator(
-            modifier = Modifier.semantics {
-                contentDescription = loadingLabel
-            },
-        )
+        ShadowGlassPanel(radius = ShadowRadii.Panel) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .padding(ShadowSpacing.Xl)
+                    .semantics {
+                        contentDescription = loadingLabel
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimelineComposer() {
+    ShadowGlassPanel(radius = ShadowRadii.Panel) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(ShadowSpacing.Md),
+            horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.room_timeline_composer_placeholder),
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.room_timeline_composer_send),
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+            )
+        }
     }
 }
 
@@ -177,19 +280,27 @@ private fun RoomTimelineEmptyState() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+        ShadowGlassPanel(
+            modifier = Modifier.widthIn(max = 360.dp),
+            radius = ShadowRadii.Panel,
         ) {
-            Text(
-                text = stringResource(R.string.room_timeline_empty_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = stringResource(R.string.room_timeline_empty_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(
+                modifier = Modifier.padding(ShadowSpacing.Xl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Sm),
+            ) {
+                Text(
+                    text = stringResource(R.string.room_timeline_empty_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(R.string.room_timeline_empty_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -200,21 +311,29 @@ private fun RoomTimelineErrorState(onEvent: (RoomTimelineEvent) -> Unit) {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+        ShadowGlassPanel(
+            modifier = Modifier.widthIn(max = 360.dp),
+            radius = ShadowRadii.Panel,
         ) {
-            Text(
-                text = stringResource(R.string.room_timeline_error_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = stringResource(R.string.room_timeline_error_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Button(onClick = { onEvent(RoomTimelineEvent.RetryRequested) }) {
-                Text(text = stringResource(R.string.room_timeline_retry))
+            Column(
+                modifier = Modifier.padding(ShadowSpacing.Xl),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
+            ) {
+                Text(
+                    text = stringResource(R.string.room_timeline_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(R.string.room_timeline_error_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(onClick = { onEvent(RoomTimelineEvent.RetryRequested) }) {
+                    Text(text = stringResource(R.string.room_timeline_retry))
+                }
             }
         }
     }

--- a/apps/android/features/timeline/src/main/res/values/strings.xml
+++ b/apps/android/features/timeline/src/main/res/values/strings.xml
@@ -1,5 +1,12 @@
 <resources>
     <string name="room_timeline_default_title">Room</string>
+    <string name="room_timeline_room_symbol">SC</string>
+    <string name="room_timeline_shell_label">Timeline shell</string>
+    <string name="room_timeline_call_action">Call</string>
+    <string name="room_timeline_video_action">Video</string>
+    <string name="room_timeline_day_today">Today</string>
+    <string name="room_timeline_composer_placeholder">Message shell</string>
+    <string name="room_timeline_composer_send">Send</string>
     <string name="room_timeline_loading">Loading messages</string>
     <string name="room_timeline_empty_title">No messages yet</string>
     <string name="room_timeline_empty_body">Messages in this room will appear here.</string>

--- a/apps/ios/Packages/Package.swift
+++ b/apps/ios/Packages/Package.swift
@@ -41,7 +41,8 @@ let package = Package(
             name: "ShadowChatAppShell",
             dependencies: [
                 "ShadowDesignSystem",
-                "ShadowChatListFeature"
+                "ShadowChatListFeature",
+                "ShadowRoomTimelineFeature"
             ]
         ),
         .testTarget(

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
@@ -1,27 +1,287 @@
 import ShadowChatListFeature
 import ShadowDesignSystem
+import ShadowRoomTimelineFeature
 import SwiftUI
 
 public struct ShadowChatRootView: View {
+    @StateObject private var router: ShadowChatRouter
     @StateObject private var chatListViewModel: ChatListViewModel
 
     public init() {
+        let router = ShadowChatRouter()
+        _router = StateObject(wrappedValue: router)
         _chatListViewModel = StateObject(
-            wrappedValue: ChatListViewModel(repository: EmptyChatListRepository())
+            wrappedValue: ChatListViewModel(
+                repository: DemoChatListRepository(),
+                onRoomSelected: { [weak router] roomId in
+                    router?.selectedRoomId = roomId
+                }
+            )
         )
     }
 
     public var body: some View {
-        NavigationStack {
-            ChatListRoute(viewModel: chatListViewModel)
+        ShadowLiquidBackground {
+            TabView {
+                NavigationStack {
+                    if let roomId = router.selectedRoomId {
+                        VStack(spacing: ShadowSpacing.sm) {
+                            Button {
+                                router.selectedRoomId = nil
+                            } label: {
+                                Label("Chats", systemImage: "chevron.left")
+                            }
+                            .buttonStyle(.bordered)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, ShadowSpacing.lg)
+
+                            RoomTimelineRoute(
+                                viewModel: RoomTimelineViewModel(
+                                    roomId: roomId,
+                                    repository: DemoRoomTimelineRepository()
+                                )
+                            )
+                        }
+                    } else {
+                        ChatListRoute(viewModel: chatListViewModel)
+                    }
+                }
+                .tabItem {
+                    Label("Chats", systemImage: "bubble.left.and.bubble.right.fill")
+                }
+
+                CallsShellView()
+                    .tabItem {
+                        Label("Calls", systemImage: "phone.fill")
+                    }
+
+                UpdatesShellView()
+                    .tabItem {
+                        Label("Updates", systemImage: "sparkles")
+                    }
+
+                ProfileShellView()
+                    .tabItem {
+                        Label("Profile", systemImage: "person.crop.circle.fill")
+                    }
+
+                SettingsShellView()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape.fill")
+                    }
+            }
+            .tint(ShadowColors.unreadBadge)
         }
-        .background(ShadowColors.background)
     }
 }
 
-private struct EmptyChatListRepository: ChatListRepository {
+@MainActor
+private final class ShadowChatRouter: ObservableObject {
+    @Published var selectedRoomId: String?
+}
+
+private struct CallsShellView: View {
+    var body: some View {
+        ShellScreen(title: "Calls", symbolName: "phone.fill") {
+            PillRow(labels: ["All", "Missed", "Voicemail"])
+            ShellRow(title: "Sofia Martin", subtitle: "Outgoing call, today", trailing: "Call")
+            ShellRow(title: "Daniel Carter", subtitle: "Missed call, yesterday", trailing: "Call")
+            ShellRow(title: "Adventure Club", subtitle: "Group call preview", trailing: "Call")
+        }
+    }
+}
+
+private struct UpdatesShellView: View {
+    var body: some View {
+        ShellScreen(title: "Updates", symbolName: "sparkles") {
+            ShellRow(title: "My Status", subtitle: "Add a soft glass status update", trailing: "New")
+            ShellRow(title: "Emma Wilson", subtitle: "Recent update", trailing: "View")
+            ShellRow(title: "Family", subtitle: "Viewed update", trailing: "View")
+        }
+    }
+}
+
+private struct ProfileShellView: View {
+    var body: some View {
+        ShellScreen(title: "Profile", symbolName: "person.crop.circle.fill") {
+            AvatarHero(name: "Sofia Martin", subtitle: "Online now")
+            PillRow(labels: ["Message", "Call", "Video", "Pay"])
+            ShellRow(title: "About", subtitle: "Building calm, secure conversations.", trailing: "Edit")
+            ShellRow(title: "Media, Links, Docs", subtitle: "24 shared items", trailing: "Open")
+            ShellRow(title: "Starred Messages", subtitle: "Quick access shell", trailing: "Open")
+        }
+    }
+}
+
+private struct SettingsShellView: View {
+    var body: some View {
+        ShellScreen(title: "Settings", symbolName: "gearshape.fill") {
+            AvatarHero(name: "ShadowChat", subtitle: "Premium messenger shell")
+            ForEach([
+                "Account",
+                "Privacy",
+                "Notifications",
+                "Appearance",
+                "Chats",
+                "Storage and Data",
+                "Help Center",
+                "Invite Friends"
+            ], id: \.self) { title in
+                ShellRow(title: title, subtitle: "Settings group shell", trailing: "Open")
+            }
+        }
+    }
+}
+
+private struct ShellScreen<Content: View>: View {
+    let title: String
+    let symbolName: String
+    private let content: Content
+
+    init(
+        title: String,
+        symbolName: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.content = content()
+    }
+
+    var body: some View {
+        NavigationStack {
+            ShadowLiquidBackground {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: ShadowSpacing.md) {
+                        HStack(spacing: ShadowSpacing.md) {
+                            Image(systemName: symbolName)
+                                .font(.title2.weight(.bold))
+                                .foregroundStyle(.white)
+                                .frame(width: 54, height: 54)
+                                .background(shadowAccentGradient, in: Circle())
+
+                            Text(title)
+                                .font(.largeTitle.weight(.bold))
+                                .foregroundStyle(ShadowColors.deepText)
+                        }
+
+                        content
+                    }
+                    .padding(ShadowSpacing.lg)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct PillRow: View {
+    let labels: [String]
+
+    var body: some View {
+        HStack(spacing: ShadowSpacing.sm) {
+            ForEach(labels, id: \.self) { label in
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, ShadowSpacing.md)
+                    .padding(.vertical, ShadowSpacing.sm)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .overlay(Capsule().stroke(.white.opacity(0.55), lineWidth: 1))
+            }
+        }
+    }
+}
+
+private struct AvatarHero: View {
+    let name: String
+    let subtitle: String
+
+    var body: some View {
+        ShadowGlassPanel {
+            HStack(spacing: ShadowSpacing.md) {
+                DemoAvatar(initial: String(name.first ?? "S"))
+                VStack(alignment: .leading) {
+                    Text(name)
+                        .font(.title2.weight(.bold))
+                    Text(subtitle)
+                        .foregroundStyle(ShadowColors.softText)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(ShadowSpacing.lg)
+        }
+    }
+}
+
+private struct ShellRow: View {
+    let title: String
+    let subtitle: String
+    let trailing: String
+
+    var body: some View {
+        ShadowGlassPanel(radius: ShadowRadii.card) {
+            HStack(spacing: ShadowSpacing.md) {
+                DemoAvatar(initial: String(title.first ?? "S"))
+                VStack(alignment: .leading, spacing: ShadowSpacing.xs) {
+                    Text(title)
+                        .font(.headline.weight(.semibold))
+                    Text(subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(ShadowColors.softText)
+                }
+                Spacer()
+                Text(trailing)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(ShadowColors.unreadBadge)
+            }
+            .padding(ShadowSpacing.md)
+        }
+    }
+}
+
+private struct DemoAvatar: View {
+    let initial: String
+
+    var body: some View {
+        Text(initial.uppercased())
+            .font(.headline.weight(.bold))
+            .foregroundStyle(.white)
+            .frame(width: 52, height: 52)
+            .background(shadowAccentGradient, in: Circle())
+    }
+}
+
+private struct DemoChatListRepository: ChatListRepository {
     func loadChatList() async throws -> [ChatListItemViewState] {
-        []
+        [
+            ChatListItemViewState(roomId: "sofia", title: "Sofia Martin", previewText: "Hey! Are we still on for dinner tonight?", sentAtLabel: "09:41", unreadCount: 2, trustLevel: .verified, isFavorite: true),
+            ChatListItemViewState(roomId: "design-squad", title: "Design Squad", previewText: "Liam: I’ll share the assets here.", sentAtLabel: "09:12", unreadCount: 8, trustLevel: .standard, isFavorite: true),
+            ChatListItemViewState(roomId: "jason", title: "Jason Lee", previewText: "Sounds good, talk soon!", sentAtLabel: "Yesterday", unreadCount: 0, trustLevel: .verified),
+            ChatListItemViewState(roomId: "family", title: "Family", previewText: "Mom: Don’t forget Sunday lunch at grandma’s!", sentAtLabel: "Sun", unreadCount: 4, trustLevel: .standard),
+            ChatListItemViewState(roomId: "emma", title: "Emma Wilson", previewText: "Looks amazing!", sentAtLabel: "Sat", unreadCount: 1, trustLevel: .verified),
+            ChatListItemViewState(roomId: "adventure", title: "Adventure Club", previewText: "Trail photos are ready.", sentAtLabel: "Fri", unreadCount: 0, trustLevel: .reduced),
+            ChatListItemViewState(roomId: "noah", title: "Noah Johnson", previewText: "Can you review this later?", sentAtLabel: "Thu", unreadCount: 0, trustLevel: .standard),
+            ChatListItemViewState(roomId: "daniel", title: "Daniel Carter", previewText: "Call me when you are free.", sentAtLabel: "Wed", unreadCount: 3, trustLevel: .reduced)
+        ]
+    }
+}
+
+private struct DemoRoomTimelineRepository: RoomTimelineRepository {
+    func loadTimeline(roomId: String) async throws -> RoomTimelineSnapshotViewState {
+        let rooms = try await DemoChatListRepository().loadChatList()
+        let title = rooms.first { $0.roomId == roomId }?.title ?? "Conversation"
+
+        return RoomTimelineSnapshotViewState(
+            roomId: roomId,
+            roomTitle: title,
+            items: [
+                RoomTimelineItemViewState(messageId: "m1", senderDisplayName: title, body: "Hey! Are we still on for dinner tonight?", sentAtLabel: "09:41", direction: .incoming, deliveryState: .read),
+                RoomTimelineItemViewState(messageId: "m2", senderDisplayName: nil, body: "Yes. I will be there at 8.", sentAtLabel: "09:43", direction: .outgoing, deliveryState: .delivered),
+                RoomTimelineItemViewState(messageId: "m3", senderDisplayName: title, body: "Perfect. I saved us a table near the window.", sentAtLabel: "09:44", direction: .incoming, deliveryState: .read),
+                RoomTimelineItemViewState(messageId: "m4", senderDisplayName: nil, body: "Voice preview and media cards will land in the send pipeline slice.", sentAtLabel: "09:45", direction: .outgoing, deliveryState: .sent)
+            ]
+        )
     }
 }
 

--- a/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListModels.swift
+++ b/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListModels.swift
@@ -4,21 +4,30 @@ import ShadowDesignSystem
 public struct ChatListItemViewState: Equatable, Identifiable, Sendable {
     public let roomId: String
     public let title: String
+    public let previewText: String
+    public let sentAtLabel: String
     public let unreadCount: Int
     public let trustLevel: ChatListTrustLevel
+    public let isFavorite: Bool
 
     public var id: String { roomId }
 
     public init(
         roomId: String,
         title: String,
+        previewText: String = "",
+        sentAtLabel: String = "",
         unreadCount: Int,
-        trustLevel: ChatListTrustLevel
+        trustLevel: ChatListTrustLevel,
+        isFavorite: Bool = false
     ) {
         self.roomId = roomId
         self.title = title
+        self.previewText = previewText
+        self.sentAtLabel = sentAtLabel
         self.unreadCount = unreadCount
         self.trustLevel = trustLevel
+        self.isFavorite = isFavorite
     }
 }
 

--- a/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListView.swift
+++ b/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListView.swift
@@ -14,53 +14,134 @@ public struct ChatListView: View {
     }
 
     public var body: some View {
-        content
+        ShadowLiquidBackground {
+            VStack(alignment: .leading, spacing: ShadowSpacing.md) {
+                header
+                content
+            }
+            .padding(.horizontal, ShadowSpacing.lg)
+            .padding(.top, ShadowSpacing.xl)
+        }
             .navigationTitle("Chats")
-            .background(ShadowColors.background)
+            .navigationBarTitleDisplayMode(.inline)
             .task {
                 send(.appeared)
             }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: ShadowSpacing.md) {
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: ShadowSpacing.xs) {
+                    Text("Chats")
+                        .font(.largeTitle.weight(.bold))
+                        .foregroundStyle(ShadowColors.deepText)
+
+                    Text("Private rooms, soft signals, clear trust.")
+                        .font(.subheadline)
+                        .foregroundStyle(ShadowColors.softText)
+                }
+
+                Spacer()
+
+                Image(systemName: "plus")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 48, height: 48)
+                    .background(shadowAccentGradient, in: Circle())
+                    .accessibilityLabel("New chat")
+            }
+
+            HStack(spacing: ShadowSpacing.sm) {
+                filterChip("All")
+                filterChip("Unread")
+                filterChip("Groups")
+                filterChip("Favorites")
+            }
+
+            Text("Search conversations")
+                .font(.subheadline)
+                .foregroundStyle(ShadowColors.softText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, ShadowSpacing.md)
+                .padding(.vertical, ShadowSpacing.sm)
+                .background(.ultraThinMaterial, in: Capsule())
+                .overlay(Capsule().stroke(.white.opacity(0.55), lineWidth: 1))
+        }
+    }
+
+    private func filterChip(_ title: String) -> some View {
+        Text(title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(ShadowColors.deepText)
+            .padding(.horizontal, ShadowSpacing.md)
+            .padding(.vertical, ShadowSpacing.sm)
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().stroke(.white.opacity(0.55), lineWidth: 1))
     }
 
     @ViewBuilder
     private var content: some View {
         switch state {
         case .loading:
-            ProgressView("Loading chats")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .accessibilityLabel("Loading chats")
-        case let .loaded(items):
-            List(items) { item in
-                Button {
-                    send(.roomSelected(roomId: item.roomId))
-                } label: {
-                    ChatListRow(item: item)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(accessibilityLabel(for: item))
+            Spacer()
+            ShadowGlassPanel {
+                ProgressView("Loading chats")
+                    .padding(ShadowSpacing.xl)
+                    .accessibilityLabel("Loading chats")
             }
-            .listStyle(.plain)
+            .frame(maxWidth: .infinity)
+            Spacer()
+        case let .loaded(items):
+            ScrollView {
+                LazyVStack(spacing: ShadowSpacing.md) {
+                    ForEach(items) { item in
+                        Button {
+                            send(.roomSelected(roomId: item.roomId))
+                        } label: {
+                            ChatListRow(item: item)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(accessibilityLabel(for: item))
+                    }
+                }
+                .padding(.vertical, ShadowSpacing.xs)
+            }
             .refreshable {
                 send(.refreshRequested)
             }
         case .empty:
-            ContentUnavailableView(
-                "No chats yet",
-                systemImage: "bubble.left.and.bubble.right",
-                description: Text("New conversations will appear here.")
+            Spacer()
+            EmptyGlassState(
+                title: "No chats yet",
+                symbolName: "bubble.left.and.bubble.right",
+                description: "New conversations will appear here."
             )
             .accessibilityLabel("No chats yet")
+            Spacer()
         case .failed:
-            ContentUnavailableView {
-                Label("Chats unavailable", systemImage: "exclamationmark.triangle")
-            } description: {
-                Text("Try again when your connection is stable.")
-            } actions: {
-                Button("Retry") {
-                    send(.retryRequested)
+            Spacer()
+            ShadowGlassPanel {
+                VStack(spacing: ShadowSpacing.md) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.largeTitle.weight(.semibold))
+                        .foregroundStyle(ShadowColors.trustColor(for: .reduced))
+                    Text("Chats unavailable")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(ShadowColors.deepText)
+                    Text("Try again when your connection is stable.")
+                        .font(.body)
+                        .foregroundStyle(ShadowColors.softText)
+                    Button("Retry") {
+                        send(.retryRequested)
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
+                .multilineTextAlignment(.center)
+                .padding(ShadowSpacing.xl)
             }
             .accessibilityLabel("Chats unavailable")
+            Spacer()
         }
     }
 
@@ -88,28 +169,71 @@ private struct ChatListRow: View {
     let item: ChatListItemViewState
 
     var body: some View {
-        HStack(spacing: ShadowSpacing.md) {
-            TrustIndicator(trustLevel: item.trustLevel)
+        ShadowGlassPanel(radius: ShadowRadii.card) {
+            HStack(spacing: ShadowSpacing.md) {
+                AvatarBadge(title: item.title)
 
-            Text(item.title)
-                .font(.headline)
-                .foregroundStyle(.primary)
-                .lineLimit(2)
+                VStack(alignment: .leading, spacing: ShadowSpacing.xs) {
+                    HStack(spacing: ShadowSpacing.sm) {
+                        Text(item.title)
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(ShadowColors.deepText)
+                            .lineLimit(1)
+
+                        TrustIndicator(trustLevel: item.trustLevel)
+                    }
+
+                    Text(item.previewText.isEmpty ? previewLine : item.previewText)
+                        .font(.subheadline)
+                        .foregroundStyle(ShadowColors.softText)
+                        .lineLimit(1)
+                }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            if item.unreadCount > 0 {
-                Text("\(item.unreadCount)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.white)
-                    .monospacedDigit()
-                    .padding(.horizontal, ShadowSpacing.sm)
-                    .padding(.vertical, ShadowSpacing.xs)
-                    .background(Capsule().fill(ShadowColors.unreadBadge))
-                    .accessibilityHidden(true)
+                if !item.sentAtLabel.isEmpty {
+                    Text(item.sentAtLabel)
+                        .font(.caption2)
+                        .foregroundStyle(ShadowColors.softText)
+                }
+
+                if item.unreadCount > 0 {
+                    Text("\(item.unreadCount)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .monospacedDigit()
+                        .padding(.horizontal, ShadowSpacing.sm)
+                        .padding(.vertical, ShadowSpacing.xs)
+                        .background(shadowAccentGradient, in: Capsule())
+                        .accessibilityHidden(true)
+                }
             }
+            .padding(.horizontal, ShadowSpacing.md)
+            .padding(.vertical, ShadowSpacing.md)
         }
-        .padding(.vertical, ShadowSpacing.sm)
-        .contentShape(Rectangle())
+        .contentShape(RoundedRectangle(cornerRadius: ShadowRadii.card, style: .continuous))
+    }
+
+    private var previewLine: String {
+        switch item.trustLevel {
+        case .verified:
+            return "Verified secure conversation"
+        case .standard:
+            return "Standard private conversation"
+        case .reduced:
+            return "Reduced trust context"
+        }
+    }
+}
+
+private struct AvatarBadge: View {
+    let title: String
+
+    var body: some View {
+        Text(String(title.first ?? " ").uppercased())
+            .font(.title3.weight(.bold))
+            .foregroundStyle(.white)
+            .frame(width: 54, height: 54)
+            .background(shadowAccentGradient, in: Circle())
     }
 }
 
@@ -133,5 +257,30 @@ private struct TrustIndicator: View {
         case .reduced:
             return "exclamationmark.triangle.fill"
         }
+    }
+}
+
+private struct EmptyGlassState: View {
+    let title: String
+    let symbolName: String
+    let description: String
+
+    var body: some View {
+        ShadowGlassPanel {
+            VStack(spacing: ShadowSpacing.md) {
+                Image(systemName: symbolName)
+                    .font(.largeTitle.weight(.semibold))
+                    .foregroundStyle(shadowAccentGradient)
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(ShadowColors.deepText)
+                Text(description)
+                    .font(.body)
+                    .foregroundStyle(ShadowColors.softText)
+            }
+            .multilineTextAlignment(.center)
+            .padding(ShadowSpacing.xl)
+        }
+        .frame(maxWidth: .infinity)
     }
 }

--- a/apps/ios/Packages/Sources/ShadowDesignSystem/ShadowColors.swift
+++ b/apps/ios/Packages/Sources/ShadowDesignSystem/ShadowColors.swift
@@ -7,19 +7,28 @@ public enum ShadowTrustTone: Equatable {
 }
 
 public enum ShadowColors {
-    public static let background = Color(.systemBackground)
-    public static let secondaryBackground = Color(.secondarySystemBackground)
-    public static let separator = Color(.separator)
-    public static let unreadBadge = Color.accentColor
+    public static let background = Color(red: 1.0, green: 0.985, blue: 1.0)
+    public static let lavenderMist = Color(red: 0.955, green: 0.935, blue: 1.0)
+    public static let iceBlue = Color(red: 0.92, green: 0.965, blue: 1.0)
+    public static let blush = Color(red: 1.0, green: 0.935, blue: 0.975)
+    public static let secondaryBackground = Color.white.opacity(0.72)
+    public static let separator = Color.white.opacity(0.62)
+    public static let unreadBadge = Color(red: 0.40, green: 0.34, blue: 1.0)
+    public static let accentStart = Color(red: 0.48, green: 0.38, blue: 1.0)
+    public static let accentEnd = Color(red: 0.22, green: 0.65, blue: 1.0)
+    public static let deepText = Color(.label)
+    public static let softText = Color(.secondaryLabel)
+    public static let incomingBubble = Color.white.opacity(0.82)
+    public static let outgoingBubble = Color(red: 0.93, green: 0.905, blue: 1.0).opacity(0.94)
 
     public static func trustColor(for tone: ShadowTrustTone) -> Color {
         switch tone {
         case .verified:
-            return Color.green
+            return Color(red: 0.13, green: 0.71, blue: 0.45)
         case .standard:
-            return Color.secondary
+            return Color(red: 0.57, green: 0.54, blue: 0.65)
         case .reduced:
-            return Color.orange
+            return Color(red: 1.0, green: 0.62, blue: 0.18)
         }
     }
 }

--- a/apps/ios/Packages/Sources/ShadowDesignSystem/ShadowLiquidGlass.swift
+++ b/apps/ios/Packages/Sources/ShadowDesignSystem/ShadowLiquidGlass.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+public enum ShadowRadii {
+    public static let panel: CGFloat = 32
+    public static let card: CGFloat = 26
+    public static let bubble: CGFloat = 24
+    public static let control: CGFloat = 22
+}
+
+public var shadowAccentGradient: LinearGradient {
+    LinearGradient(
+        colors: [
+            ShadowColors.accentStart,
+            ShadowColors.accentEnd
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}
+
+public struct ShadowLiquidBackground<Content: View>: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private let content: Content
+
+    public init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    public var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: backgroundColors,
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            content
+        }
+    }
+
+    private var backgroundColors: [Color] {
+        if colorScheme == .dark {
+            return [
+                Color(red: 0.07, green: 0.065, blue: 0.10),
+                Color(red: 0.11, green: 0.095, blue: 0.19),
+                Color(red: 0.075, green: 0.14, blue: 0.22),
+                Color(red: 0.14, green: 0.095, blue: 0.16)
+            ]
+        }
+
+        return [
+            ShadowColors.background,
+            ShadowColors.lavenderMist,
+            ShadowColors.iceBlue,
+            ShadowColors.blush
+        ]
+    }
+}
+
+public struct ShadowGlassPanel<Content: View>: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private let radius: CGFloat
+    private let content: Content
+
+    public init(
+        radius: CGFloat = ShadowRadii.panel,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.radius = radius
+        self.content = content()
+    }
+
+    public var body: some View {
+        content
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: radius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .stroke(colorScheme == .dark ? .white.opacity(0.22) : .white.opacity(0.62), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.10), radius: 24, x: 0, y: 14)
+    }
+}

--- a/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineView.swift
+++ b/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineView.swift
@@ -14,12 +14,52 @@ public struct RoomTimelineView: View {
     }
 
     public var body: some View {
-        content
+        ShadowLiquidBackground {
+            VStack(spacing: ShadowSpacing.md) {
+                header
+                content
+            }
+            .padding(.horizontal, ShadowSpacing.lg)
+            .padding(.top, ShadowSpacing.xl)
+        }
             .navigationTitle(title)
-            .background(ShadowColors.background)
+            .navigationBarTitleDisplayMode(.inline)
             .task {
                 send(.appeared)
             }
+    }
+
+    private var header: some View {
+        ShadowGlassPanel {
+            HStack(spacing: ShadowSpacing.md) {
+                Text("SC")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 48, height: 48)
+                    .background(shadowAccentGradient, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: ShadowSpacing.xs) {
+                    Text(title)
+                        .font(.title2.weight(.bold))
+                        .foregroundStyle(ShadowColors.deepText)
+                        .lineLimit(1)
+                    Text("Timeline shell")
+                        .font(.subheadline)
+                        .foregroundStyle(ShadowColors.softText)
+                }
+
+                Spacer()
+
+                Image(systemName: "phone.fill")
+                    .foregroundStyle(ShadowColors.unreadBadge)
+                    .accessibilityLabel("Call")
+                Image(systemName: "video.fill")
+                    .foregroundStyle(ShadowColors.unreadBadge)
+                    .accessibilityLabel("Video")
+            }
+            .padding(ShadowSpacing.md)
+        }
     }
 
     private var title: String {
@@ -35,41 +75,88 @@ public struct RoomTimelineView: View {
     private var content: some View {
         switch state {
         case .loading:
-            ProgressView("Loading messages")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .accessibilityLabel("Loading messages")
-        case let .loaded(_, items):
-            ScrollView {
-                LazyVStack(spacing: ShadowSpacing.sm) {
-                    ForEach(items) { item in
-                        RoomTimelineMessageRow(item: item)
-                    }
-                }
-                .padding(.horizontal, ShadowSpacing.lg)
-                .padding(.vertical, ShadowSpacing.md)
+            Spacer()
+            ShadowGlassPanel {
+                ProgressView("Loading messages")
+                    .padding(ShadowSpacing.xl)
+                    .accessibilityLabel("Loading messages")
             }
-            .refreshable {
-                send(.refreshRequested)
+            .frame(maxWidth: .infinity)
+            Spacer()
+        case let .loaded(_, items):
+            VStack(spacing: ShadowSpacing.md) {
+                ScrollView {
+                    LazyVStack(spacing: ShadowSpacing.sm) {
+                        Text("Today")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(ShadowColors.softText)
+                            .padding(.horizontal, ShadowSpacing.md)
+                            .padding(.vertical, ShadowSpacing.xs)
+                            .background(.ultraThinMaterial, in: Capsule())
+
+                        ForEach(items) { item in
+                            RoomTimelineMessageRow(item: item)
+                        }
+                    }
+                    .padding(.horizontal, ShadowSpacing.lg)
+                    .padding(.vertical, ShadowSpacing.md)
+                }
+                .refreshable {
+                    send(.refreshRequested)
+                }
+
+                TimelineComposer()
             }
         case .empty:
-            ContentUnavailableView(
-                "No messages yet",
-                systemImage: "bubble.left",
-                description: Text("Messages in this room will appear here.")
+            Spacer()
+            RoomTimelineGlassState(
+                title: "No messages yet",
+                symbolName: "bubble.left",
+                description: "Messages in this room will appear here."
             )
             .accessibilityLabel("No messages yet")
+            Spacer()
         case .failed:
-            ContentUnavailableView {
-                Label("Messages unavailable", systemImage: "exclamationmark.triangle")
-            } description: {
-                Text("Try again when your connection is stable.")
-            } actions: {
-                Button("Retry") {
-                    send(.retryRequested)
+            Spacer()
+            ShadowGlassPanel {
+                VStack(spacing: ShadowSpacing.md) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.largeTitle.weight(.semibold))
+                        .foregroundStyle(ShadowColors.trustColor(for: .reduced))
+                    Text("Messages unavailable")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(ShadowColors.deepText)
+                    Text("Try again when your connection is stable.")
+                        .font(.body)
+                        .foregroundStyle(ShadowColors.softText)
+                    Button("Retry") {
+                        send(.retryRequested)
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
+                .multilineTextAlignment(.center)
+                .padding(ShadowSpacing.xl)
             }
             .accessibilityLabel("Messages unavailable")
+            Spacer()
         }
+    }
+}
+
+private struct TimelineComposer: View {
+    var body: some View {
+        ShadowGlassPanel {
+            HStack(spacing: ShadowSpacing.sm) {
+                Text("Message shell")
+                    .foregroundStyle(ShadowColors.softText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Image(systemName: "paperplane.fill")
+                    .foregroundStyle(ShadowColors.unreadBadge)
+                    .accessibilityLabel("Send")
+            }
+            .padding(ShadowSpacing.md)
+        }
+        .padding(.horizontal, ShadowSpacing.lg)
     }
 }
 
@@ -136,20 +223,25 @@ private struct MessageBubble: View {
             .foregroundStyle(.secondary)
         }
         .padding(.horizontal, ShadowSpacing.md)
-        .padding(.vertical, ShadowSpacing.sm)
+        .padding(.vertical, ShadowSpacing.md)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: ShadowRadii.bubble, style: .continuous)
                 .fill(backgroundStyle)
         )
+        .overlay(
+            RoundedRectangle(cornerRadius: ShadowRadii.bubble, style: .continuous)
+                .stroke(.white.opacity(0.48), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 14, x: 0, y: 8)
         .frame(maxWidth: 320, alignment: item.direction == .outgoing ? .trailing : .leading)
     }
 
     private var backgroundStyle: Color {
         switch item.direction {
         case .incoming:
-            return ShadowColors.secondaryBackground
+            return ShadowColors.incomingBubble
         case .outgoing:
-            return Color.accentColor.opacity(0.18)
+            return ShadowColors.outgoingBubble
         }
     }
 
@@ -166,5 +258,30 @@ private struct MessageBubble: View {
         case .failed:
             return "failed"
         }
+    }
+}
+
+private struct RoomTimelineGlassState: View {
+    let title: String
+    let symbolName: String
+    let description: String
+
+    var body: some View {
+        ShadowGlassPanel {
+            VStack(spacing: ShadowSpacing.md) {
+                Image(systemName: symbolName)
+                    .font(.largeTitle.weight(.semibold))
+                    .foregroundStyle(shadowAccentGradient)
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(ShadowColors.deepText)
+                Text(description)
+                    .font(.body)
+                    .foregroundStyle(ShadowColors.softText)
+            }
+            .multilineTextAlignment(.center)
+            .padding(ShadowSpacing.xl)
+        }
+        .frame(maxWidth: .infinity)
     }
 }

--- a/docs/design/CHAT-DESIGN-MOTION-SPEC.md
+++ b/docs/design/CHAT-DESIGN-MOTION-SPEC.md
@@ -25,8 +25,16 @@ ShadowChat soll sich wie ein moderner Premium-Messenger anfühlen: hohe visuelle
 - sanfte Zellen-Transitions
 - klare Unread-Badges
 - Typing-Zustände weich statt hektisch
+- helle Glas-Cards auf Pastell-Hintergrund
+- Trust-Indikatoren bleiben sichtbar, aber nicht aggressiv
 
 ## Chat-Raum
 - neue Nachrichten mit leichter Materialisierung
 - Reply und Reactions mit kurzen Übergängen
 - Composer als schwebende Oberfläche
+- Incoming- und Outgoing-Bubbles nutzen helle, abgesetzte Liquid-Glass-nahe Flächen
+
+## Mobile App Shell
+- Bottom Navigation hostet die vorhandenen Hauptbereiche als Shell
+- Chats bleibt der Startbereich
+- Calls, Updates, Profile und Settings sind visuelle Shells ohne Produktlogik, bis eigene Slices folgen

--- a/docs/design/DESIGN-TOKENS.md
+++ b/docs/design/DESIGN-TOKENS.md
@@ -7,18 +7,23 @@
 - Violet
 - Cyan
 - Emerald
+- Liquid Light: Porcelain, Lavender Mist, Ice Blue, Blush, Deep Text, Soft Text
 
 ## Gradient
 - Core Aurora
 - Ice Signal
 - Secure Trust
 - Night Depth
+- Messenger Accent: Lila-Blau-Verlauf für primäre Akzente, Unread-Badges und fokussierte Controls
 
 ## Material
 - base
 - frosted
 - liquid
 - hero
+- glass panel
+- floating card
+- message bubble
 
 ## Motion
 - xs
@@ -31,3 +36,4 @@
 - klare Token-Namen
 - keine Screen-spezifischen Einzelwerte im Produktkern
 - Reduce Motion und Reduce Transparency werden mitgedacht
+- Liquid-Glass-Flächen bleiben hell, lesbar und subtil; Transparenz darf keine Texte destabilisieren

--- a/docs/technical-design/TD-0008-mobile-repo-structure.md
+++ b/docs/technical-design/TD-0008-mobile-repo-structure.md
@@ -41,6 +41,8 @@ Startstruktur für ShadowChat im Repo.
 - iOS `ShadowChat` hostet `ShadowChatRootView` aus `ShadowChatAppShell` als Startscreen.
 - Der Chat-Listen-Slice ist buildbar, testbar und ohne Matrix- oder Rust-Bridge verdrahtet.
 - Der Room-Timeline-Shell-Slice liegt als eigenes Android-Feature-Modul und als eigenes iOS SwiftPM-Feature-Target vor.
+- Der Liquid-Glass-UI-Slice erweitert die bestehenden Designsystem-Module um helle Pastell-Hintergründe, Glas-Panels, stärkere Rundungen und Lila-Blau-Akzente.
+- Android und iOS besitzen eine minimale Bottom-Tab-App-Shell; nur `Chats` ist fachlich verdrahtet, `Calls`, `Updates`, `Profile` und `Settings` bleiben reine UI-Shells ohne Produktlogik.
 
 ## Regeln
 - Feature-Grenzen bleiben sichtbar


### PR DESCRIPTION
## Zusammenfassung

Closes #3.

Dieser PR baut den bestehenden Mobile-UI-Slice in Richtung der geforderten hellen Liquid-Glass-Messenger-Referenz um, ohne neue Matrix-, Auth-, Send-, Push-, Bridge- oder Persistenzlogik einzuf�hren.

## �nderungen

- erweitert Android `:designsystem` und iOS `ShadowDesignSystem` um helle Pastellfarben, Glasfl�chen, starke Rundungen und Lila-Blau-Akzente
- erg�nzt Android/iOS App-Shells mit Bottom Tabs f�r Chats, Calls, Updates, Profile und Settings
- verdrahtet die Chat-Liste mit hochwertigen Demo-Daten aus InMemory-Repositories
- erg�nzt eine visuelle Conversation/Timeline-Shell aus der Chat-Liste heraus
- �berarbeitet Chat-Liste und Timeline mit Such-/Filterfl�chen, schwebenden Cards, Bubbles, Composer-Shell und klarer Trust-Sichtbarkeit
- dokumentiert die neuen Liquid-Glass-Tokens und die Mobile-Shell-Struktur

## Validierung

- `git diff --check` erfolgreich, nur bekannte LF/CRLF-Warnungen auf Windows
- `cd apps/android && .\gradlew.bat tasks --console=plain` erfolgreich
- `cd apps/android && .\gradlew.bat assembleDebug --console=plain` erfolgreich
- `cd apps/android && .\gradlew.bat testDebugUnitTest --console=plain` erfolgreich
- `cd apps/android && .\gradlew.bat lint --console=plain` erfolgreich
- `cd apps/ios/Packages && swift test` lokal nicht ausf�hrbar, weil `swift` auf der Windows-Maschine nicht installiert ist; iOS wird �ber macOS-CI validiert

## Risiken

- iOS muss im CI/macOS-Runner kompilieren, lokal ist kein SwiftPM-/Xcode-Tooling verf�gbar.
- Demo-Daten sind absichtlich nur UI-Shell-/InMemory-Daten und keine Matrix-Daten.
- Calls, Updates, Profile und Settings sind bewusst reine UI-Shells ohne Produktoperationen.
