### PR TITLE
Polish liquid glass navigation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Android, iOS und Rust CI sind als zentrale Validierungspfade fuer mobile Slices etabliert.
 - Mobile UI-Dokumentation beschreibt die verbleibenden visuellen Polish-Punkte.
 - Motion- und Interaktionsverhalten fuer Mobile Shell, Chat-Liste und Timeline wurde mit kurzen, Reduce-Motion-bewussten Uebergaengen verfeinert.
+- Lokale Shell-Navigation zwischen Chat-Liste und Timeline wurde fuer Android und iOS plattformnaeher gepolisht.
 
 ### Known Gaps
 

--- a/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
@@ -2,6 +2,7 @@ package com.shadowchat.app
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.compose.BackHandler
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.AnimatedContent
@@ -29,7 +30,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -104,6 +104,14 @@ private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
     var selectedTab by remember { mutableStateOf(AppTab.Chats) }
     var selectedRoomId by remember { mutableStateOf<String?>(null) }
     val motionEnabled = shadowMotionEnabled()
+    val closeConversation = {
+        selectedRoomId = null
+        selectedTab = AppTab.Chats
+    }
+
+    BackHandler(enabled = selectedTab == AppTab.Chats && selectedRoomId != null) {
+        closeConversation()
+    }
 
     ShadowLiquidBackground(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -156,7 +164,10 @@ private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
                                 if (animatedRoomId == null) {
                                     ChatListRoute(
                                         viewModel = chatListViewModel,
-                                        onRoomSelected = { selectedRoomId = it },
+                                        onRoomSelected = {
+                                            selectedTab = AppTab.Chats
+                                            selectedRoomId = it
+                                        },
                                     )
                                 } else {
                                     val timelineViewModel: RoomTimelineViewModel = viewModel(
@@ -167,15 +178,10 @@ private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
                                         ),
                                     )
 
-                                    Column {
-                                        Button(
-                                            onClick = { selectedRoomId = null },
-                                            modifier = Modifier.padding(start = ShadowSpacing.Lg, top = ShadowSpacing.Lg),
-                                        ) {
-                                            Text(text = stringResource(R.string.timeline_back_to_chats))
-                                        }
-                                        RoomTimelineRoute(viewModel = timelineViewModel)
-                                    }
+                                    RoomTimelineRoute(
+                                        viewModel = timelineViewModel,
+                                        onBackRequested = closeConversation,
+                                    )
                                 }
                             }
                         }

--- a/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineRoute.kt
+++ b/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineRoute.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 fun RoomTimelineRoute(
     viewModel: RoomTimelineViewModel,
     modifier: Modifier = Modifier,
+    onBackRequested: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -21,5 +22,6 @@ fun RoomTimelineRoute(
         state = state,
         onEvent = viewModel::onEvent,
         modifier = modifier,
+        onBackRequested = onBackRequested,
     )
 }

--- a/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineScreen.kt
+++ b/apps/android/features/timeline/src/main/java/com/shadowchat/features/timeline/RoomTimelineScreen.kt
@@ -56,6 +56,7 @@ fun RoomTimelineScreen(
     state: RoomTimelineUiState,
     onEvent: (RoomTimelineEvent) -> Unit,
     modifier: Modifier = Modifier,
+    onBackRequested: (() -> Unit)? = null,
 ) {
     ShadowLiquidBackground(
         modifier = modifier.fillMaxSize(),
@@ -67,7 +68,10 @@ fun RoomTimelineScreen(
                 .padding(top = ShadowSpacing.Xl),
             verticalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
         ) {
-            TimelineHeader(title = timelineTitle(state))
+            TimelineHeader(
+                title = timelineTitle(state),
+                onBackRequested = onBackRequested,
+            )
 
             when (state) {
                 RoomTimelineUiState.Loading -> RoomTimelineLoadingState()
@@ -84,7 +88,10 @@ fun RoomTimelineScreen(
 }
 
 @Composable
-private fun TimelineHeader(title: String) {
+private fun TimelineHeader(
+    title: String,
+    onBackRequested: (() -> Unit)?,
+) {
     ShadowGlassPanel(radius = ShadowRadii.Panel) {
         Row(
             modifier = Modifier
@@ -93,6 +100,13 @@ private fun TimelineHeader(title: String) {
             horizontalArrangement = Arrangement.spacedBy(ShadowSpacing.Md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (onBackRequested != null) {
+                HeaderAction(
+                    icon = TimelineActionIcon.Back,
+                    label = stringResource(R.string.room_timeline_back_to_chats),
+                    onClick = onBackRequested,
+                )
+            }
             Box(
                 modifier = Modifier
                     .clip(RoundedCornerShape(20.dp))
@@ -131,8 +145,12 @@ private fun TimelineHeader(title: String) {
 }
 
 @Composable
-private fun HeaderAction(icon: TimelineActionIcon, label: String) {
-    val modifier = Modifier.shadowPressScale()
+private fun HeaderAction(
+    icon: TimelineActionIcon,
+    label: String,
+    onClick: (() -> Unit)? = null,
+) {
+    val modifier = Modifier.shadowPressScale(onClick = onClick)
 
     ShadowGlassPanel(radius = ShadowRadii.Control) {
         TimelineActionIconCanvas(
@@ -336,7 +354,7 @@ private fun ComposerAction(
 }
 
 @Composable
-private fun Modifier.shadowPressScale(): Modifier {
+private fun Modifier.shadowPressScale(onClick: (() -> Unit)? = null): Modifier {
     val motionEnabled = shadowMotionEnabled()
     var pressed by remember { mutableStateOf(false) }
     val scale by animateFloatAsState(
@@ -360,12 +378,16 @@ private fun Modifier.shadowPressScale(): Modifier {
                         pressed = false
                     }
                 },
+                onTap = {
+                    onClick?.invoke()
+                },
             )
         }
 }
 
 private enum class TimelineActionIcon {
     Attach,
+    Back,
     Call,
     Mic,
     Send,
@@ -381,6 +403,22 @@ private fun TimelineActionIconCanvas(
     Canvas(modifier = modifier) {
         val stroke = Stroke(width = 2.2.dp.toPx(), cap = StrokeCap.Round)
         when (icon) {
+            TimelineActionIcon.Back -> {
+                drawLine(
+                    color = color,
+                    start = androidx.compose.ui.geometry.Offset(size.width * 0.68f, size.height * 0.18f),
+                    end = androidx.compose.ui.geometry.Offset(size.width * 0.32f, size.height * 0.5f),
+                    strokeWidth = stroke.width,
+                    cap = StrokeCap.Round,
+                )
+                drawLine(
+                    color = color,
+                    start = androidx.compose.ui.geometry.Offset(size.width * 0.32f, size.height * 0.5f),
+                    end = androidx.compose.ui.geometry.Offset(size.width * 0.68f, size.height * 0.82f),
+                    strokeWidth = stroke.width,
+                    cap = StrokeCap.Round,
+                )
+            }
             TimelineActionIcon.Attach -> {
                 drawLine(
                     color = color,

--- a/apps/android/features/timeline/src/main/res/values/strings.xml
+++ b/apps/android/features/timeline/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="room_timeline_default_title">Room</string>
+    <string name="room_timeline_back_to_chats">Back to chats</string>
     <string name="room_timeline_room_symbol">SC</string>
     <string name="room_timeline_shell_label">Timeline shell</string>
     <string name="room_timeline_call_action">Call</string>

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
@@ -14,7 +14,7 @@ public struct ShadowChatRootView: View {
             wrappedValue: ChatListViewModel(
                 repository: DemoChatListRepository(),
                 onRoomSelected: { [weak router] roomId in
-                    router?.selectedRoomId = roomId
+                    router?.openRoom(roomId)
                 }
             )
         )
@@ -22,19 +22,10 @@ public struct ShadowChatRootView: View {
 
     public var body: some View {
         ShadowLiquidBackground {
-            TabView {
-                NavigationStack {
-                    if let roomId = router.selectedRoomId {
-                        VStack(spacing: ShadowSpacing.sm) {
-                            Button {
-                                router.selectedRoomId = nil
-                            } label: {
-                                Label("Chats", systemImage: "chevron.left")
-                            }
-                            .buttonStyle(.bordered)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, ShadowSpacing.lg)
-
+            TabView(selection: $router.selectedTab) {
+                NavigationStack(path: $router.chatPath) {
+                    ChatListRoute(viewModel: chatListViewModel)
+                        .navigationDestination(for: String.self) { roomId in
                             RoomTimelineRoute(
                                 viewModel: RoomTimelineViewModel(
                                     roomId: roomId,
@@ -42,42 +33,68 @@ public struct ShadowChatRootView: View {
                                 )
                             )
                         }
-                    } else {
-                        ChatListRoute(viewModel: chatListViewModel)
-                    }
                 }
                 .tabItem {
                     Label("Chats", systemImage: "bubble.left.and.bubble.right.fill")
                 }
+                .tag(ShadowShellTab.chats)
 
                 CallsShellView()
                     .tabItem {
                         Label("Calls", systemImage: "phone.fill")
                     }
+                    .tag(ShadowShellTab.calls)
 
                 UpdatesShellView()
                     .tabItem {
                         Label("Updates", systemImage: "sparkles")
                     }
+                    .tag(ShadowShellTab.updates)
 
                 ProfileShellView()
                     .tabItem {
                         Label("Profile", systemImage: "person.crop.circle.fill")
                     }
+                    .tag(ShadowShellTab.profile)
 
                 SettingsShellView()
                     .tabItem {
                         Label("Settings", systemImage: "gearshape.fill")
                     }
+                    .tag(ShadowShellTab.settings)
             }
             .tint(ShadowColors.unreadBadge)
+            .onChange(of: router.selectedTab) { _, tab in
+                if tab != .chats {
+                    router.closeRoom()
+                }
+            }
         }
     }
 }
 
+private enum ShadowShellTab: Hashable {
+    case chats
+    case calls
+    case updates
+    case profile
+    case settings
+}
+
 @MainActor
 private final class ShadowChatRouter: ObservableObject {
-    @Published var selectedRoomId: String?
+    @Published var selectedTab: ShadowShellTab = .chats
+    @Published var chatPath = NavigationPath()
+
+    func openRoom(_ roomId: String) {
+        selectedTab = .chats
+        chatPath = NavigationPath()
+        chatPath.append(roomId)
+    }
+
+    func closeRoom() {
+        chatPath = NavigationPath()
+    }
 }
 
 private struct CallsShellView: View {

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@
 ## Design
 - `design/CHAT-DESIGN-MOTION-SPEC.md`
 - `design/DESIGN-TOKENS.md`
+- `design/navigation-flow-liquid-glass.md`
+- `design/visual-review-liquid-glass.md`
 
 ## Technisches Design
 - `technical-design/TD-0001-system-architecture.md`

--- a/docs/design/navigation-flow-liquid-glass.md
+++ b/docs/design/navigation-flow-liquid-glass.md
@@ -1,0 +1,43 @@
+# Navigation Flow: Liquid Glass Mobile Shell
+
+## Ziel
+
+Dieser Slice beschreibt die lokale Shell-Navigation der Liquid-Glass-Mobile-UI. Er fuehrt keine Matrix-, Auth-, Send-, Push-, Bridge- oder Produktlogik ein.
+
+## Scope
+
+- Chat-Liste fuehrt lokal in die Conversation/Timeline-Shell.
+- Der ausgewaehlte Demo-Raum wird nur im lokalen Shell-State gehalten.
+- Es gibt keine Persistenz, keine Netzwerkzugriffe und keine echte Matrix-Raum-Navigation.
+- Calls, Updates, Profile und Settings bleiben reine UI-Shells.
+
+## Android
+
+- `MainActivity` haelt den lokalen Shell-State fuer aktiven Tab und ausgewaehlten Raum.
+- `ChatListRoute` bleibt der Einstieg fuer den Chats-Tab.
+- `RoomTimelineRoute` wird weiterverwendet und erhaelt nur ein optionales `onBackRequested`.
+- `BackHandler` ist nur aktiv, wenn im Chats-Tab eine Conversation offen ist.
+- System-Back schliesst in diesem Zustand die Conversation und kehrt zur Chat-Liste zurueck, statt die App unerwartet zu schliessen.
+- Der Timeline-Header enthaelt einen lokalen Back-Button, Avatar/Room-Symbol, Raumtitel sowie Call-/Video-Shell-Actions ohne echte Aktion.
+- Tab-Wechsel setzt die lokale Conversation-Auswahl zurueck.
+
+## iOS
+
+- `ShadowChatRootView` nutzt `TabView` mit stabilen Tab-Tags.
+- Der Chats-Tab nutzt einen nativen `NavigationStack`.
+- Chat-Auswahl pusht die `RoomTimelineRoute` ueber den lokalen `NavigationPath`.
+- Der native iOS-Back-Button des `NavigationStack` fuehrt von der Timeline zur Chat-Liste zurueck.
+- Tab-Wechsel aus dem Chats-Tab heraus leert den lokalen Chat-Pfad.
+
+## Motion
+
+- Bestehende Motion-Tokens bleiben massgeblich.
+- Android nutzt die vorhandenen dezenten `AnimatedContent`-Uebergaenge.
+- iOS nutzt native NavigationStack-Transitions.
+- Reduce Motion bleibt ueber die bestehenden Plattformsignale respektiert.
+
+## Offene Punkte
+
+- Spaetere echte Navigation muss an Matrix-Session- und Room-List-Contracts angebunden werden.
+- Deep Links, Push-Open, Auth-Restore und Bridge-Kontexte sind eigene Slices.
+- Calls, Updates, Profile und Settings benoetigen spaeter eigene Feature-Flows.


### PR DESCRIPTION
## Zusammenfassung
- polisht lokale Chat-Liste-zu-Timeline-Navigation ohne Matrix- oder Produktlogik
- Android: System-Back schliesst offene Conversation, Timeline-Header erhaelt lokalen Back-Button
- iOS: Chats-Tab nutzt echten `NavigationStack` mit lokalem `NavigationPath`
- Tab-Wechsel-State bleibt stabil; Nicht-Chat-Tabs bleiben reine UI-Shells
- dokumentiert den Liquid-Glass-Navigation-Flow und aktualisiert Changelog/Docs-Index

## Validierung
- `cd apps/android && .\gradlew.bat assembleDebug --console=plain`
- `cd apps/android && .\gradlew.bat testDebugUnitTest --console=plain`
- `cd apps/android && .\gradlew.bat lint --console=plain`
- `git diff --check`
- `cd apps/ios/Packages && swift test` versucht; lokal nicht moeglich, weil `swift` auf Windows nicht installiert ist

## Nicht enthalten
- keine Matrix-SDK-Integration
- keine Authentifizierung
- keine echte Send-/Call-/Push-/Bridge-Logik
- keine Persistenz oder Netzwerkzugriffe