### PR TITLE
Clean up mobile shell demo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Mobile UI-Dokumentation beschreibt die verbleibenden visuellen Polish-Punkte.
 - Motion- und Interaktionsverhalten fuer Mobile Shell, Chat-Liste und Timeline wurde mit kurzen, Reduce-Motion-bewussten Uebergaengen verfeinert.
 - Lokale Shell-Navigation zwischen Chat-Liste und Timeline wurde fuer Android und iOS plattformnaeher gepolisht.
+- Runtime-Demo-Daten und lokale InMemory-Repositories der Mobile App-Shell wurden fuer Android und iOS gekapselt.
 
 ### Known Gaps
 

--- a/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
@@ -64,17 +64,11 @@ import com.shadowchat.designsystem.ShadowSpacing
 import com.shadowchat.designsystem.shadowAccentGradient
 import com.shadowchat.designsystem.shadowMotionEnabled
 import com.shadowchat.designsystem.shadowScreenTransitionMillis
-import com.shadowchat.features.chatlist.ChatListItemUi
 import com.shadowchat.features.chatlist.ChatListRepository
 import com.shadowchat.features.chatlist.ChatListRoute
-import com.shadowchat.features.chatlist.ChatListTrustLevel
 import com.shadowchat.features.chatlist.ChatListViewModel
-import com.shadowchat.features.timeline.RoomTimelineDeliveryState
-import com.shadowchat.features.timeline.RoomTimelineItemUi
-import com.shadowchat.features.timeline.RoomTimelineMessageDirection
 import com.shadowchat.features.timeline.RoomTimelineRepository
 import com.shadowchat.features.timeline.RoomTimelineRoute
-import com.shadowchat.features.timeline.RoomTimelineSnapshotUi
 import com.shadowchat.features.timeline.RoomTimelineViewModel
 
 class MainActivity : ComponentActivity() {
@@ -309,48 +303,39 @@ private fun ShadowTabIcon(tab: AppTab, selected: Boolean) {
 @Composable
 private fun CallsShell() {
     ShellScaffold(title = stringResource(R.string.tab_calls), symbol = stringResource(R.string.tab_calls_symbol)) {
-        PillRow(listOf("All", "Missed", "Voicemail"))
-        ShellRow("Sofia Martin", "Outgoing call, today", "Call")
-        ShellRow("Daniel Carter", "Missed call, yesterday", "Call")
-        ShellRow("Adventure Club", "Group call preview", "Call")
+        PillRow(ShadowDemoData.callFilters)
+        ShadowDemoData.callRows.forEach { row ->
+            ShellRow(row.title, row.subtitle, row.trailing)
+        }
     }
 }
 
 @Composable
 private fun UpdatesShell() {
     ShellScaffold(title = stringResource(R.string.tab_updates), symbol = stringResource(R.string.tab_updates_symbol)) {
-        ShellRow("My Status", "Add a soft glass status update", "New")
-        ShellRow("Emma Wilson", "Recent update", "View")
-        ShellRow("Family", "Viewed update", "View")
+        ShadowDemoData.updateRows.forEach { row ->
+            ShellRow(row.title, row.subtitle, row.trailing)
+        }
     }
 }
 
 @Composable
 private fun ProfileShell() {
     ShellScaffold(title = stringResource(R.string.tab_profile), symbol = stringResource(R.string.tab_profile_symbol)) {
-        AvatarHero("Sofia Martin", "Online now")
-        PillRow(listOf("Message", "Call", "Video", "Pay"))
-        ShellRow("About", "Building calm, secure conversations.", "Edit")
-        ShellRow("Media, Links, Docs", "24 shared items", "Open")
-        ShellRow("Starred Messages", "Quick access shell", "Open")
+        AvatarHero(ShadowDemoData.profileHero.name, ShadowDemoData.profileHero.subtitle)
+        PillRow(ShadowDemoData.profileActions)
+        ShadowDemoData.profileRows.forEach { row ->
+            ShellRow(row.title, row.subtitle, row.trailing)
+        }
     }
 }
 
 @Composable
 private fun SettingsShell() {
     ShellScaffold(title = stringResource(R.string.tab_settings), symbol = stringResource(R.string.tab_settings_symbol)) {
-        AvatarHero("ShadowChat", "Premium messenger shell")
-        listOf(
-            "Account",
-            "Privacy",
-            "Notifications",
-            "Appearance",
-            "Chats",
-            "Storage and Data",
-            "Help Center",
-            "Invite Friends",
-        ).forEach { title ->
-            ShellRow(title, "Settings group shell", "Open")
+        AvatarHero(ShadowDemoData.settingsHero.name, ShadowDemoData.settingsHero.subtitle)
+        ShadowDemoData.settingsRows.forEach { row ->
+            ShellRow(row.title, row.subtitle, row.trailing)
         }
     }
 }
@@ -468,35 +453,6 @@ private enum class AppTab(
     Updates(R.string.tab_updates, R.string.tab_updates_symbol),
     Profile(R.string.tab_profile, R.string.tab_profile_symbol),
     Settings(R.string.tab_settings, R.string.tab_settings_symbol),
-}
-
-private object DemoChatListRepository : ChatListRepository {
-    override suspend fun loadChatList(): List<ChatListItemUi> = listOf(
-        ChatListItemUi("sofia", "Sofia Martin", "Hey! Are we still on for dinner tonight?", "09:41", 2, ChatListTrustLevel.Verified, true),
-        ChatListItemUi("design-squad", "Design Squad", "Liam: I will share the assets here.", "09:12", 8, ChatListTrustLevel.Standard, true),
-        ChatListItemUi("jason", "Jason Lee", "Sounds good, talk soon!", "Yesterday", 0, ChatListTrustLevel.Verified),
-        ChatListItemUi("family", "Family", "Mom: Do not forget Sunday lunch at grandma's!", "Sun", 4, ChatListTrustLevel.Standard),
-        ChatListItemUi("emma", "Emma Wilson", "Looks amazing!", "Sat", 1, ChatListTrustLevel.Verified),
-        ChatListItemUi("adventure", "Adventure Club", "Trail photos are ready.", "Fri", 0, ChatListTrustLevel.Reduced),
-        ChatListItemUi("noah", "Noah Johnson", "Can you review this later?", "Thu", 0, ChatListTrustLevel.Standard),
-        ChatListItemUi("daniel", "Daniel Carter", "Call me when you are free.", "Wed", 3, ChatListTrustLevel.Reduced),
-    )
-}
-
-private object DemoRoomTimelineRepository : RoomTimelineRepository {
-    override suspend fun loadTimeline(roomId: String): RoomTimelineSnapshotUi {
-        val title = DemoChatListRepository.loadChatList().firstOrNull { it.roomId == roomId }?.title ?: "Conversation"
-        return RoomTimelineSnapshotUi(
-            roomId = roomId,
-            roomTitle = title,
-            items = listOf(
-                RoomTimelineItemUi("m1", title, "Hey! Are we still on for dinner tonight?", "09:41", RoomTimelineMessageDirection.Incoming, RoomTimelineDeliveryState.Read),
-                RoomTimelineItemUi("m2", null, "Yes. I will be there at 8.", "09:43", RoomTimelineMessageDirection.Outgoing, RoomTimelineDeliveryState.Delivered),
-                RoomTimelineItemUi("m3", title, "Perfect. I saved us a table near the window.", "09:44", RoomTimelineMessageDirection.Incoming, RoomTimelineDeliveryState.Read),
-                RoomTimelineItemUi("m4", null, "Voice preview and media cards will land in the send pipeline slice.", "09:45", RoomTimelineMessageDirection.Outgoing, RoomTimelineDeliveryState.Sent),
-            ),
-        )
-    }
 }
 
 private class ChatListViewModelFactory(

--- a/apps/android/app/src/main/java/com/shadowchat/app/ShadowDemoData.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/ShadowDemoData.kt
@@ -1,0 +1,159 @@
+package com.shadowchat.app
+
+import com.shadowchat.features.chatlist.ChatListItemUi
+import com.shadowchat.features.chatlist.ChatListRepository
+import com.shadowchat.features.chatlist.ChatListTrustLevel
+import com.shadowchat.features.timeline.RoomTimelineDeliveryState
+import com.shadowchat.features.timeline.RoomTimelineItemUi
+import com.shadowchat.features.timeline.RoomTimelineMessageDirection
+import com.shadowchat.features.timeline.RoomTimelineRepository
+import com.shadowchat.features.timeline.RoomTimelineSnapshotUi
+
+internal data class ShadowShellRowData(
+    val title: String,
+    val subtitle: String,
+    val trailing: String,
+)
+
+internal data class ShadowShellHeroData(
+    val name: String,
+    val subtitle: String,
+)
+
+internal object ShadowDemoData {
+    val chatRooms: List<ChatListItemUi> = listOf(
+        ChatListItemUi("sofia", "Sofia Martin", "Hey! Are we still on for dinner tonight?", "09:41", 2, ChatListTrustLevel.Verified, true),
+        ChatListItemUi("design-squad", "Design Squad", "Liam: I will share the assets here.", "09:12", 8, ChatListTrustLevel.Standard, true),
+        ChatListItemUi("jason", "Jason Lee", "Sounds good, talk soon!", "Yesterday", 0, ChatListTrustLevel.Verified),
+        ChatListItemUi("family", "Family", "Mom: Do not forget Sunday lunch at grandma's!", "Sun", 4, ChatListTrustLevel.Standard),
+        ChatListItemUi("emma", "Emma Wilson", "Looks amazing!", "Sat", 1, ChatListTrustLevel.Verified),
+        ChatListItemUi("adventure", "Adventure Club", "Trail photos are ready.", "Fri", 0, ChatListTrustLevel.Reduced),
+        ChatListItemUi("noah", "Noah Johnson", "Can you review this later?", "Thu", 0, ChatListTrustLevel.Standard),
+        ChatListItemUi("daniel", "Daniel Carter", "Call me when you are free.", "Wed", 3, ChatListTrustLevel.Reduced),
+    )
+
+    val callFilters: List<String> = listOf("All", "Missed", "Voicemail")
+
+    val callRows: List<ShadowShellRowData> = listOf(
+        ShadowShellRowData("Sofia Martin", "Outgoing call, today", "Call"),
+        ShadowShellRowData("Daniel Carter", "Missed call, yesterday", "Call"),
+        ShadowShellRowData("Adventure Club", "Group call preview", "Call"),
+    )
+
+    val updateRows: List<ShadowShellRowData> = listOf(
+        ShadowShellRowData("My Status", "Add a soft glass status update", "New"),
+        ShadowShellRowData("Emma Wilson", "Recent update", "View"),
+        ShadowShellRowData("Family", "Viewed update", "View"),
+    )
+
+    val profileHero = ShadowShellHeroData("Sofia Martin", "Online now")
+    val profileActions: List<String> = listOf("Message", "Call", "Video", "Pay")
+    val profileRows: List<ShadowShellRowData> = listOf(
+        ShadowShellRowData("About", "Building calm, secure conversations.", "Edit"),
+        ShadowShellRowData("Media, Links, Docs", "24 shared items", "Open"),
+        ShadowShellRowData("Starred Messages", "Quick access shell", "Open"),
+    )
+
+    val settingsHero = ShadowShellHeroData("ShadowChat", "Premium messenger shell")
+    val settingsRows: List<ShadowShellRowData> = listOf(
+        "Account",
+        "Privacy",
+        "Notifications",
+        "Appearance",
+        "Chats",
+        "Storage and Data",
+        "Help Center",
+        "Invite Friends",
+    ).map { title ->
+        ShadowShellRowData(title, "Settings group shell", "Open")
+    }
+
+    fun timelineSnapshot(roomId: String): RoomTimelineSnapshotUi {
+        val roomTitle = chatRooms.firstOrNull { it.roomId == roomId }?.title ?: "Conversation"
+        return RoomTimelineSnapshotUi(
+            roomId = roomId,
+            roomTitle = roomTitle,
+            items = timelineItems(roomId = roomId, roomTitle = roomTitle),
+        )
+    }
+
+    private fun timelineItems(roomId: String, roomTitle: String): List<RoomTimelineItemUi> = when (roomId) {
+        "sofia" -> listOf(
+            incoming("sofia-1", roomTitle, "Hey! Are we still on for dinner tonight?", "09:41"),
+            outgoing("sofia-2", "Yes. I will be there at 8.", "09:43", RoomTimelineDeliveryState.Delivered),
+            incoming("sofia-3", roomTitle, "Perfect. I saved us a table near the window.", "09:44"),
+            outgoing("sofia-4", "Voice preview and media cards will land in the send pipeline slice.", "09:45", RoomTimelineDeliveryState.Sent),
+        )
+        "design-squad" -> listOf(
+            incoming("design-1", "Liam", "I will share the assets here.", "09:12"),
+            outgoing("design-2", "Great. Keep the glass cards readable on small screens.", "09:14", RoomTimelineDeliveryState.Delivered),
+            incoming("design-3", "Maya", "The lavender accent works best when the header stays calm.", "09:18"),
+        )
+        "jason" -> listOf(
+            incoming("jason-1", roomTitle, "Sounds good, talk soon!", "Yesterday"),
+            outgoing("jason-2", "Thanks. I will send the notes after lunch.", "Yesterday", RoomTimelineDeliveryState.Read),
+        )
+        "family" -> listOf(
+            incoming("family-1", "Mom", "Do not forget Sunday lunch at grandma's!", "Sun"),
+            outgoing("family-2", "I have it saved. I will bring dessert.", "Sun", RoomTimelineDeliveryState.Delivered),
+            incoming("family-3", "Alex", "I can pick up drinks on the way.", "Sun"),
+        )
+        "emma" -> listOf(
+            incoming("emma-1", roomTitle, "Looks amazing!", "Sat"),
+            outgoing("emma-2", "Thank you. The final polish is starting to feel right.", "Sat", RoomTimelineDeliveryState.Read),
+        )
+        "adventure" -> listOf(
+            incoming("adventure-1", roomTitle, "Trail photos are ready.", "Fri"),
+            outgoing("adventure-2", "Nice. Send the album when you can.", "Fri", RoomTimelineDeliveryState.Sent),
+            incoming("adventure-3", roomTitle, "Reminder: this demo room keeps reduced trust visible.", "Fri", RoomTimelineDeliveryState.Read),
+        )
+        "noah" -> listOf(
+            incoming("noah-1", roomTitle, "Can you review this later?", "Thu"),
+            outgoing("noah-2", "Yes, I will take a look tonight.", "Thu", RoomTimelineDeliveryState.Delivered),
+        )
+        "daniel" -> listOf(
+            incoming("daniel-1", roomTitle, "Call me when you are free.", "Wed"),
+            outgoing("daniel-2", "I am in a meeting now. I will call after.", "Wed", RoomTimelineDeliveryState.Sent),
+        )
+        else -> listOf(
+            incoming("unknown-1", roomTitle, "This local demo room has no Matrix-backed timeline yet.", "Now"),
+        )
+    }
+
+    private fun incoming(
+        id: String,
+        sender: String,
+        body: String,
+        time: String,
+        deliveryState: RoomTimelineDeliveryState = RoomTimelineDeliveryState.Read,
+    ) = RoomTimelineItemUi(
+        messageId = id,
+        senderDisplayName = sender,
+        body = body,
+        sentAtLabel = time,
+        direction = RoomTimelineMessageDirection.Incoming,
+        deliveryState = deliveryState,
+    )
+
+    private fun outgoing(
+        id: String,
+        body: String,
+        time: String,
+        deliveryState: RoomTimelineDeliveryState,
+    ) = RoomTimelineItemUi(
+        messageId = id,
+        senderDisplayName = null,
+        body = body,
+        sentAtLabel = time,
+        direction = RoomTimelineMessageDirection.Outgoing,
+        deliveryState = deliveryState,
+    )
+}
+
+internal object DemoChatListRepository : ChatListRepository {
+    override suspend fun loadChatList(): List<ChatListItemUi> = ShadowDemoData.chatRooms
+}
+
+internal object DemoRoomTimelineRepository : RoomTimelineRepository {
+    override suspend fun loadTimeline(roomId: String): RoomTimelineSnapshotUi = ShadowDemoData.timelineSnapshot(roomId)
+}

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
@@ -100,10 +100,10 @@ private final class ShadowChatRouter: ObservableObject {
 private struct CallsShellView: View {
     var body: some View {
         ShellScreen(title: "Calls", symbolName: "phone.fill") {
-            PillRow(labels: ["All", "Missed", "Voicemail"])
-            ShellRow(title: "Sofia Martin", subtitle: "Outgoing call, today", trailing: "Call")
-            ShellRow(title: "Daniel Carter", subtitle: "Missed call, yesterday", trailing: "Call")
-            ShellRow(title: "Adventure Club", subtitle: "Group call preview", trailing: "Call")
+            PillRow(labels: ShadowDemoData.callFilters)
+            ForEach(ShadowDemoData.callRows) { row in
+                ShellRow(title: row.title, subtitle: row.subtitle, trailing: row.trailing)
+            }
         }
     }
 }
@@ -111,9 +111,9 @@ private struct CallsShellView: View {
 private struct UpdatesShellView: View {
     var body: some View {
         ShellScreen(title: "Updates", symbolName: "sparkles") {
-            ShellRow(title: "My Status", subtitle: "Add a soft glass status update", trailing: "New")
-            ShellRow(title: "Emma Wilson", subtitle: "Recent update", trailing: "View")
-            ShellRow(title: "Family", subtitle: "Viewed update", trailing: "View")
+            ForEach(ShadowDemoData.updateRows) { row in
+                ShellRow(title: row.title, subtitle: row.subtitle, trailing: row.trailing)
+            }
         }
     }
 }
@@ -121,11 +121,11 @@ private struct UpdatesShellView: View {
 private struct ProfileShellView: View {
     var body: some View {
         ShellScreen(title: "Profile", symbolName: "person.crop.circle.fill") {
-            AvatarHero(name: "Sofia Martin", subtitle: "Online now")
-            PillRow(labels: ["Message", "Call", "Video", "Pay"])
-            ShellRow(title: "About", subtitle: "Building calm, secure conversations.", trailing: "Edit")
-            ShellRow(title: "Media, Links, Docs", subtitle: "24 shared items", trailing: "Open")
-            ShellRow(title: "Starred Messages", subtitle: "Quick access shell", trailing: "Open")
+            AvatarHero(name: ShadowDemoData.profileHero.name, subtitle: ShadowDemoData.profileHero.subtitle)
+            PillRow(labels: ShadowDemoData.profileActions)
+            ForEach(ShadowDemoData.profileRows) { row in
+                ShellRow(title: row.title, subtitle: row.subtitle, trailing: row.trailing)
+            }
         }
     }
 }
@@ -133,18 +133,9 @@ private struct ProfileShellView: View {
 private struct SettingsShellView: View {
     var body: some View {
         ShellScreen(title: "Settings", symbolName: "gearshape.fill") {
-            AvatarHero(name: "ShadowChat", subtitle: "Premium messenger shell")
-            ForEach([
-                "Account",
-                "Privacy",
-                "Notifications",
-                "Appearance",
-                "Chats",
-                "Storage and Data",
-                "Help Center",
-                "Invite Friends"
-            ], id: \.self) { title in
-                ShellRow(title: title, subtitle: "Settings group shell", trailing: "Open")
+            AvatarHero(name: ShadowDemoData.settingsHero.name, subtitle: ShadowDemoData.settingsHero.subtitle)
+            ForEach(ShadowDemoData.settingsRows) { row in
+                ShellRow(title: row.title, subtitle: row.subtitle, trailing: row.trailing)
             }
         }
     }
@@ -266,39 +257,6 @@ private struct DemoAvatar: View {
             .foregroundStyle(.white)
             .frame(width: 52, height: 52)
             .background(shadowAccentGradient, in: Circle())
-    }
-}
-
-private struct DemoChatListRepository: ChatListRepository {
-    func loadChatList() async throws -> [ChatListItemViewState] {
-        [
-            ChatListItemViewState(roomId: "sofia", title: "Sofia Martin", previewText: "Hey! Are we still on for dinner tonight?", sentAtLabel: "09:41", unreadCount: 2, trustLevel: .verified, isFavorite: true),
-            ChatListItemViewState(roomId: "design-squad", title: "Design Squad", previewText: "Liam: I'll share the assets here.", sentAtLabel: "09:12", unreadCount: 8, trustLevel: .standard, isFavorite: true),
-            ChatListItemViewState(roomId: "jason", title: "Jason Lee", previewText: "Sounds good, talk soon!", sentAtLabel: "Yesterday", unreadCount: 0, trustLevel: .verified),
-            ChatListItemViewState(roomId: "family", title: "Family", previewText: "Mom: Don't forget Sunday lunch at grandma's!", sentAtLabel: "Sun", unreadCount: 4, trustLevel: .standard),
-            ChatListItemViewState(roomId: "emma", title: "Emma Wilson", previewText: "Looks amazing!", sentAtLabel: "Sat", unreadCount: 1, trustLevel: .verified),
-            ChatListItemViewState(roomId: "adventure", title: "Adventure Club", previewText: "Trail photos are ready.", sentAtLabel: "Fri", unreadCount: 0, trustLevel: .reduced),
-            ChatListItemViewState(roomId: "noah", title: "Noah Johnson", previewText: "Can you review this later?", sentAtLabel: "Thu", unreadCount: 0, trustLevel: .standard),
-            ChatListItemViewState(roomId: "daniel", title: "Daniel Carter", previewText: "Call me when you are free.", sentAtLabel: "Wed", unreadCount: 3, trustLevel: .reduced)
-        ]
-    }
-}
-
-private struct DemoRoomTimelineRepository: RoomTimelineRepository {
-    func loadTimeline(roomId: String) async throws -> RoomTimelineSnapshotViewState {
-        let rooms = try await DemoChatListRepository().loadChatList()
-        let title = rooms.first { $0.roomId == roomId }?.title ?? "Conversation"
-
-        return RoomTimelineSnapshotViewState(
-            roomId: roomId,
-            roomTitle: title,
-            items: [
-                RoomTimelineItemViewState(messageId: "m1", senderDisplayName: title, body: "Hey! Are we still on for dinner tonight?", sentAtLabel: "09:41", direction: .incoming, deliveryState: .read),
-                RoomTimelineItemViewState(messageId: "m2", senderDisplayName: nil, body: "Yes. I will be there at 8.", sentAtLabel: "09:43", direction: .outgoing, deliveryState: .delivered),
-                RoomTimelineItemViewState(messageId: "m3", senderDisplayName: title, body: "Perfect. I saved us a table near the window.", sentAtLabel: "09:44", direction: .incoming, deliveryState: .read),
-                RoomTimelineItemViewState(messageId: "m4", senderDisplayName: nil, body: "Voice preview and media cards will land in the send pipeline slice.", sentAtLabel: "09:45", direction: .outgoing, deliveryState: .sent)
-            ]
-        )
     }
 }
 

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowDemoData.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowDemoData.swift
@@ -1,0 +1,178 @@
+import ShadowChatListFeature
+import ShadowRoomTimelineFeature
+
+struct ShadowShellRowData: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let trailing: String
+
+    init(title: String, subtitle: String, trailing: String) {
+        self.id = "\(title)-\(subtitle)-\(trailing)"
+        self.title = title
+        self.subtitle = subtitle
+        self.trailing = trailing
+    }
+}
+
+struct ShadowShellHeroData {
+    let name: String
+    let subtitle: String
+}
+
+enum ShadowDemoData {
+    static let chatRooms: [ChatListItemViewState] = [
+        ChatListItemViewState(roomId: "sofia", title: "Sofia Martin", previewText: "Hey! Are we still on for dinner tonight?", sentAtLabel: "09:41", unreadCount: 2, trustLevel: .verified, isFavorite: true),
+        ChatListItemViewState(roomId: "design-squad", title: "Design Squad", previewText: "Liam: I'll share the assets here.", sentAtLabel: "09:12", unreadCount: 8, trustLevel: .standard, isFavorite: true),
+        ChatListItemViewState(roomId: "jason", title: "Jason Lee", previewText: "Sounds good, talk soon!", sentAtLabel: "Yesterday", unreadCount: 0, trustLevel: .verified),
+        ChatListItemViewState(roomId: "family", title: "Family", previewText: "Mom: Don't forget Sunday lunch at grandma's!", sentAtLabel: "Sun", unreadCount: 4, trustLevel: .standard),
+        ChatListItemViewState(roomId: "emma", title: "Emma Wilson", previewText: "Looks amazing!", sentAtLabel: "Sat", unreadCount: 1, trustLevel: .verified),
+        ChatListItemViewState(roomId: "adventure", title: "Adventure Club", previewText: "Trail photos are ready.", sentAtLabel: "Fri", unreadCount: 0, trustLevel: .reduced),
+        ChatListItemViewState(roomId: "noah", title: "Noah Johnson", previewText: "Can you review this later?", sentAtLabel: "Thu", unreadCount: 0, trustLevel: .standard),
+        ChatListItemViewState(roomId: "daniel", title: "Daniel Carter", previewText: "Call me when you are free.", sentAtLabel: "Wed", unreadCount: 3, trustLevel: .reduced)
+    ]
+
+    static let callFilters = ["All", "Missed", "Voicemail"]
+
+    static let callRows: [ShadowShellRowData] = [
+        ShadowShellRowData(title: "Sofia Martin", subtitle: "Outgoing call, today", trailing: "Call"),
+        ShadowShellRowData(title: "Daniel Carter", subtitle: "Missed call, yesterday", trailing: "Call"),
+        ShadowShellRowData(title: "Adventure Club", subtitle: "Group call preview", trailing: "Call")
+    ]
+
+    static let updateRows: [ShadowShellRowData] = [
+        ShadowShellRowData(title: "My Status", subtitle: "Add a soft glass status update", trailing: "New"),
+        ShadowShellRowData(title: "Emma Wilson", subtitle: "Recent update", trailing: "View"),
+        ShadowShellRowData(title: "Family", subtitle: "Viewed update", trailing: "View")
+    ]
+
+    static let profileHero = ShadowShellHeroData(name: "Sofia Martin", subtitle: "Online now")
+    static let profileActions = ["Message", "Call", "Video", "Pay"]
+    static let profileRows: [ShadowShellRowData] = [
+        ShadowShellRowData(title: "About", subtitle: "Building calm, secure conversations.", trailing: "Edit"),
+        ShadowShellRowData(title: "Media, Links, Docs", subtitle: "24 shared items", trailing: "Open"),
+        ShadowShellRowData(title: "Starred Messages", subtitle: "Quick access shell", trailing: "Open")
+    ]
+
+    static let settingsHero = ShadowShellHeroData(name: "ShadowChat", subtitle: "Premium messenger shell")
+    static let settingsRows: [ShadowShellRowData] = [
+        "Account",
+        "Privacy",
+        "Notifications",
+        "Appearance",
+        "Chats",
+        "Storage and Data",
+        "Help Center",
+        "Invite Friends"
+    ].map { title in
+        ShadowShellRowData(title: title, subtitle: "Settings group shell", trailing: "Open")
+    }
+
+    static func timelineSnapshot(roomId: String) -> RoomTimelineSnapshotViewState {
+        let roomTitle = chatRooms.first { $0.roomId == roomId }?.title ?? "Conversation"
+        return RoomTimelineSnapshotViewState(
+            roomId: roomId,
+            roomTitle: roomTitle,
+            items: timelineItems(roomId: roomId, roomTitle: roomTitle)
+        )
+    }
+
+    private static func timelineItems(roomId: String, roomTitle: String) -> [RoomTimelineItemViewState] {
+        switch roomId {
+        case "sofia":
+            return [
+                incoming("sofia-1", roomTitle, "Hey! Are we still on for dinner tonight?", "09:41"),
+                outgoing("sofia-2", "Yes. I will be there at 8.", "09:43", .delivered),
+                incoming("sofia-3", roomTitle, "Perfect. I saved us a table near the window.", "09:44"),
+                outgoing("sofia-4", "Voice preview and media cards will land in the send pipeline slice.", "09:45", .sent)
+            ]
+        case "design-squad":
+            return [
+                incoming("design-1", "Liam", "I'll share the assets here.", "09:12"),
+                outgoing("design-2", "Great. Keep the glass cards readable on small screens.", "09:14", .delivered),
+                incoming("design-3", "Maya", "The lavender accent works best when the header stays calm.", "09:18")
+            ]
+        case "jason":
+            return [
+                incoming("jason-1", roomTitle, "Sounds good, talk soon!", "Yesterday"),
+                outgoing("jason-2", "Thanks. I will send the notes after lunch.", "Yesterday", .read)
+            ]
+        case "family":
+            return [
+                incoming("family-1", "Mom", "Don't forget Sunday lunch at grandma's!", "Sun"),
+                outgoing("family-2", "I have it saved. I will bring dessert.", "Sun", .delivered),
+                incoming("family-3", "Alex", "I can pick up drinks on the way.", "Sun")
+            ]
+        case "emma":
+            return [
+                incoming("emma-1", roomTitle, "Looks amazing!", "Sat"),
+                outgoing("emma-2", "Thank you. The final polish is starting to feel right.", "Sat", .read)
+            ]
+        case "adventure":
+            return [
+                incoming("adventure-1", roomTitle, "Trail photos are ready.", "Fri"),
+                outgoing("adventure-2", "Nice. Send the album when you can.", "Fri", .sent),
+                incoming("adventure-3", roomTitle, "Reminder: this demo room keeps reduced trust visible.", "Fri")
+            ]
+        case "noah":
+            return [
+                incoming("noah-1", roomTitle, "Can you review this later?", "Thu"),
+                outgoing("noah-2", "Yes, I will take a look tonight.", "Thu", .delivered)
+            ]
+        case "daniel":
+            return [
+                incoming("daniel-1", roomTitle, "Call me when you are free.", "Wed"),
+                outgoing("daniel-2", "I am in a meeting now. I will call after.", "Wed", .sent)
+            ]
+        default:
+            return [
+                incoming("unknown-1", roomTitle, "This local demo room has no Matrix-backed timeline yet.", "Now")
+            ]
+        }
+    }
+
+    private static func incoming(
+        _ id: String,
+        _ sender: String,
+        _ body: String,
+        _ time: String,
+        _ deliveryState: RoomTimelineDeliveryState = .read
+    ) -> RoomTimelineItemViewState {
+        RoomTimelineItemViewState(
+            messageId: id,
+            senderDisplayName: sender,
+            body: body,
+            sentAtLabel: time,
+            direction: .incoming,
+            deliveryState: deliveryState
+        )
+    }
+
+    private static func outgoing(
+        _ id: String,
+        _ body: String,
+        _ time: String,
+        _ deliveryState: RoomTimelineDeliveryState
+    ) -> RoomTimelineItemViewState {
+        RoomTimelineItemViewState(
+            messageId: id,
+            senderDisplayName: nil,
+            body: body,
+            sentAtLabel: time,
+            direction: .outgoing,
+            deliveryState: deliveryState
+        )
+    }
+}
+
+struct DemoChatListRepository: ChatListRepository {
+    func loadChatList() async throws -> [ChatListItemViewState] {
+        ShadowDemoData.chatRooms
+    }
+}
+
+struct DemoRoomTimelineRepository: RoomTimelineRepository {
+    func loadTimeline(roomId: String) async throws -> RoomTimelineSnapshotViewState {
+        ShadowDemoData.timelineSnapshot(roomId: roomId)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 - `technical-design/TD-0008-mobile-repo-structure.md`
 - `technical-design/TD-0009-subscriptions-billing.md`
 - `technical-design/TD-0010-versioning.md`
+- `technical-design/TD-0011-shell-state-demo-data.md`
 
 ## Architekturentscheidungen
 - `adr/ADR-0001-monorepo.md`

--- a/docs/technical-design/TD-0011-shell-state-demo-data.md
+++ b/docs/technical-design/TD-0011-shell-state-demo-data.md
@@ -1,0 +1,74 @@
+# TD-0011 Shell State und Demo-Daten
+
+## Status
+
+Akzeptiert fuer die aktuellen Mobile-UI-Shell-Slices.
+
+## Kontext
+
+Die mobile App-Shell hostet lokale UI-Slices fuer Chat-Liste, Room Timeline, Calls, Updates, Profile und Settings. Diese Shell braucht bis zur Matrix-Integration konsistente Demo-Daten, darf aber keine echte Matrix-, Auth-, Send-, Push-, Bridge-, Persistenz- oder Netzwerklogik vortaeuschen.
+
+Vor diesem Slice lagen Runtime-Demo-Daten teilweise direkt in den Shell-Views. Dadurch waren Chat-Liste, Timeline und reine Shell-Tabs schwerer voneinander zu unterscheiden, obwohl sie alle nur lokale InMemory-Daten nutzen.
+
+## Entscheidung
+
+Runtime-Demo-Daten werden pro Plattform im App-Shell-Bereich gekapselt:
+
+- Android: `apps/android/app/src/main/java/com/shadowchat/app/ShadowDemoData.kt`
+- iOS: `apps/ios/Packages/Sources/ShadowChatAppShell/ShadowDemoData.swift`
+
+Die Feature-Module behalten ihre bestehenden Contracts:
+
+- `ChatListRepository`
+- `RoomTimelineRepository`
+- Chat-/Timeline-State-Modelle
+- lokale ViewModels
+
+Die App-Shell stellt nur InMemory-Repositories bereit, die diese Contracts erfuellen. Feature-Module kennen weiterhin keine App-Shell-spezifischen Demo-Quellen und keine Matrix-Implementierungsdetails.
+
+## Demo-Room-IDs
+
+Die Runtime-Demo-Daten verwenden stabile Room-IDs, die auf Android und iOS gleich benannt sind:
+
+- `sofia`
+- `design-squad`
+- `jason`
+- `family`
+- `emma`
+- `adventure`
+- `noah`
+- `daniel`
+
+Die Chat-Liste und Timeline-Shells muessen fuer diese IDs konsistent bleiben. Wenn ein Demo-Raum ausgewaehlt wird, liefert die Timeline ein passendes lokales Snapshot-Modell fuer denselben `roomId`.
+
+## Preview- und Test-Daten
+
+Preview- und Test-Daten bleiben bewusst von Runtime-Demo-Daten getrennt:
+
+- Feature-Tests nutzen eigene Stub-Repositories.
+- SwiftUI- und Compose-Previews duerfen weiterhin eigene Preview-Fixtures verwenden.
+- Runtime-InMemory-Daten liegen in der App-Shell, nicht in Feature-Tests oder Feature-Preview-Dateien.
+
+Diese Trennung verhindert, dass spaetere Matrix-Integration versehentlich an Preview-Fixtures oder Test-Stubs gekoppelt wird.
+
+## Nicht-Ziele
+
+Dieser Slice fuehrt nicht ein:
+
+- Matrix-SDK-Integration
+- Authentifizierung
+- echte Send-Pipeline
+- Push Notifications
+- Bridge-Implementierung
+- Persistenz
+- Netzwerkzugriffe
+- echte Calls-, Payment- oder Settings-Operationen
+
+## Spaetere Ablösung
+
+Sobald Matrix-Session- und Room-List-Services bereitstehen, kann die App-Shell andere Implementierungen hinter denselben Repository-Contracts injizieren. Die aktuellen `Demo*Repository`-Implementierungen sind bewusst lokal, klein und austauschbar.
+
+## Risiken
+
+- Demo-Daten enthalten weiterhin produktnah wirkende Texte. Sie muessen bis zur echten Matrix-Anbindung klar als lokale Shell-Daten behandelt werden.
+- Calls, Updates, Profile und Settings bleiben reine Shells. Echte Produktoperationen benoetigen eigene Feature-Slices und eigene Contracts.


### PR DESCRIPTION
## Zusammenfassung
- kapselt Runtime-Demo-Daten fuer Android in ShadowDemoData.kt
- kapselt Runtime-Demo-Daten fuer iOS in ShadowDemoData.swift
- dokumentiert die Shell-State- und Demo-Daten-Grenze in TD-0011

## Validierung
- apps/android: ./gradlew.bat assembleDebug --console=plain
- apps/android: ./gradlew.bat testDebugUnitTest --console=plain
- apps/android: ./gradlew.bat lint --console=plain
- git diff --check
- apps/ios/Packages: swift test lokal nicht ausfuehrbar, weil swift auf Windows nicht installiert ist

## Risiken
- iOS SwiftPM/App-Build muss weiterhin ueber macOS-CI validiert werden
- Demo-Daten bleiben bewusst lokale Shell-Daten ohne Matrix-Anbindung