### PR TITLE
Add Rust Matrix runtime skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Visual-Polish-Slice fuer Bottom Bar, Glass Search Bar, Timeline Header, Composer und Glass Panels.
 - Matrix-Integration-Readiness-Audit fuer Mobile-, Rust-, FFI-, Repository- und Demo-Data-Grenzen.
 - Matrix Session Contract fuer Session-/Client-Lifecycle, Commands, Events, Errors und FFI-/DTO-Grenzen.
+- Rust Matrix Runtime Skeleton mit app-eigenen Session-Commands, States, Events, DTOs, Errors und No-op-Tests.
 
 ### Changed
 

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/shadow_core_domain",
   "crates/shadow_core_auth",
   "crates/shadow_core_session",
+  "crates/shadow_core_runtime",
   "crates/shadow_core_rooms",
   "crates/shadow_core_timeline",
 ]

--- a/core/rust/README.md
+++ b/core/rust/README.md
@@ -6,6 +6,7 @@ Hier liegt der gemeinsame technische Kern von ShadowChat.
 - Client
 - Auth
 - Session
+- Runtime
 - Sync
 - Rooms
 - Timeline

--- a/core/rust/crates/shadow_core_runtime/Cargo.toml
+++ b/core/rust/crates/shadow_core_runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shadow_core_runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+shadow_core_domain = { path = "../shadow_core_domain" }
+thiserror.workspace = true

--- a/core/rust/crates/shadow_core_runtime/src/command.rs
+++ b/core/rust/crates/shadow_core_runtime/src/command.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use shadow_core_domain::AccountId;
+
+use crate::dto::MatrixSessionId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionCommand {
+    DiscoverServer { server_hint: String },
+    BeginLogin { auth_hint: Option<String> },
+    CompleteLogin { callback_payload: String },
+    RestoreSession { account_id: AccountId },
+    StartSync { session_id: MatrixSessionId },
+    PauseSync { session_id: MatrixSessionId },
+    ResumeSync { session_id: MatrixSessionId },
+    Logout { session_id: MatrixSessionId },
+    ClearLocalSession { account_id: AccountId },
+}

--- a/core/rust/crates/shadow_core_runtime/src/dto.rs
+++ b/core/rust/crates/shadow_core_runtime/src/dto.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+use shadow_core_domain::AccountId;
+
+use crate::{error::SessionErrorKind, state::SessionState};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MatrixSessionId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeserverUrl(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionCapability {
+    RoomListAvailable,
+    TimelineAvailable,
+    SendAvailable,
+    MediaAvailable,
+    PushAvailable,
+    EncryptionAvailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSnapshot {
+    pub account_id: Option<AccountId>,
+    pub session_id: Option<MatrixSessionId>,
+    pub state: SessionState,
+    pub homeserver: Option<HomeserverUrl>,
+    pub user_display_name: Option<String>,
+    pub device_id: Option<DeviceId>,
+    pub capabilities: Vec<SessionCapability>,
+    pub last_sync_label: Option<String>,
+    pub error: Option<SessionErrorKind>,
+}
+
+impl SessionSnapshot {
+    pub fn not_configured() -> Self {
+        Self {
+            account_id: None,
+            session_id: None,
+            state: SessionState::NotConfigured,
+            homeserver: None,
+            user_display_name: None,
+            device_id: None,
+            capabilities: Vec::new(),
+            last_sync_label: None,
+            error: None,
+        }
+    }
+}

--- a/core/rust/crates/shadow_core_runtime/src/error.rs
+++ b/core/rust/crates/shadow_core_runtime/src/error.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionErrorKind {
+    NetworkUnavailable,
+    ServerDiscoveryFailed,
+    AuthenticationRequired,
+    AuthenticationExpired,
+    RestoreFailed,
+    DeviceUntrusted,
+    CryptoStateUnavailable,
+    SyncUnavailable,
+    RateLimited,
+    ServerRejected,
+    StorageUnavailable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SessionRuntimeError {
+    #[error("session command is not supported by the current runtime skeleton")]
+    UnsupportedCommand,
+    #[error("session id does not match the active runtime session")]
+    SessionMismatch,
+    #[error("session is not active")]
+    SessionNotActive,
+}

--- a/core/rust/crates/shadow_core_runtime/src/lib.rs
+++ b/core/rust/crates/shadow_core_runtime/src/lib.rs
@@ -1,0 +1,16 @@
+//! Matrix runtime contract skeleton.
+//!
+//! This crate intentionally contains no Matrix SDK integration, no network
+//! calls, no credential storage, and no productive persistence.
+
+pub mod command;
+pub mod dto;
+pub mod error;
+pub mod runtime;
+pub mod state;
+
+pub use command::SessionCommand;
+pub use dto::{DeviceId, HomeserverUrl, MatrixSessionId, SessionCapability, SessionSnapshot};
+pub use error::{SessionErrorKind, SessionRuntimeError};
+pub use runtime::{MatrixSessionRuntime, NoopMatrixSessionRuntime};
+pub use state::{SessionEvent, SessionState};

--- a/core/rust/crates/shadow_core_runtime/src/runtime.rs
+++ b/core/rust/crates/shadow_core_runtime/src/runtime.rs
@@ -1,0 +1,178 @@
+use shadow_core_domain::AccountId;
+
+use crate::{
+    command::SessionCommand,
+    dto::{MatrixSessionId, SessionCapability, SessionSnapshot},
+    error::{SessionErrorKind, SessionRuntimeError},
+    state::{SessionEvent, SessionState},
+};
+
+pub trait MatrixSessionRuntime {
+    fn snapshot(&self) -> SessionSnapshot;
+    fn handle_command(
+        &mut self,
+        command: SessionCommand,
+    ) -> Result<SessionEvent, SessionRuntimeError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct NoopMatrixSessionRuntime {
+    snapshot: SessionSnapshot,
+}
+
+impl NoopMatrixSessionRuntime {
+    pub fn new() -> Self {
+        Self {
+            snapshot: SessionSnapshot::not_configured(),
+        }
+    }
+
+    fn activate_for_account(&mut self, account_id: AccountId) {
+        self.snapshot.account_id = Some(account_id);
+        self.snapshot.session_id = Some(MatrixSessionId("local-session-skeleton".to_owned()));
+        self.snapshot.state = SessionState::Active;
+        self.snapshot.capabilities = vec![
+            SessionCapability::RoomListAvailable,
+            SessionCapability::TimelineAvailable,
+        ];
+        self.snapshot.error = None;
+    }
+
+    fn ensure_session(&self, session_id: &MatrixSessionId) -> Result<(), SessionRuntimeError> {
+        match &self.snapshot.session_id {
+            Some(active) if active == session_id => Ok(()),
+            _ => Err(SessionRuntimeError::SessionMismatch),
+        }
+    }
+}
+
+impl Default for NoopMatrixSessionRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MatrixSessionRuntime for NoopMatrixSessionRuntime {
+    fn snapshot(&self) -> SessionSnapshot {
+        self.snapshot.clone()
+    }
+
+    fn handle_command(
+        &mut self,
+        command: SessionCommand,
+    ) -> Result<SessionEvent, SessionRuntimeError> {
+        match command {
+            SessionCommand::DiscoverServer { .. } => {
+                self.snapshot.state = SessionState::Discovering;
+                Ok(SessionEvent::DiscoveryStarted)
+            }
+            SessionCommand::BeginLogin { .. } => {
+                self.snapshot.state = SessionState::Authenticating;
+                Ok(SessionEvent::LoginStarted)
+            }
+            SessionCommand::RestoreSession { account_id } => {
+                self.activate_for_account(account_id);
+                Ok(SessionEvent::RestoreCompleted)
+            }
+            SessionCommand::StartSync { session_id } => {
+                self.ensure_session(&session_id)?;
+                if self.snapshot.state != SessionState::Active {
+                    self.snapshot.error = Some(SessionErrorKind::SyncUnavailable);
+                    return Err(SessionRuntimeError::SessionNotActive);
+                }
+                self.snapshot.state = SessionState::Syncing;
+                Ok(SessionEvent::SyncStarted)
+            }
+            SessionCommand::PauseSync { session_id } => {
+                self.ensure_session(&session_id)?;
+                self.snapshot.state = SessionState::Active;
+                Ok(SessionEvent::SyncPaused)
+            }
+            SessionCommand::Logout { session_id } => {
+                self.ensure_session(&session_id)?;
+                self.snapshot = SessionSnapshot::not_configured();
+                self.snapshot.state = SessionState::Unauthenticated;
+                Ok(SessionEvent::LoggedOut)
+            }
+            SessionCommand::ClearLocalSession { .. } => {
+                self.snapshot = SessionSnapshot::not_configured();
+                Ok(SessionEvent::LoggedOut)
+            }
+            SessionCommand::CompleteLogin { .. } | SessionCommand::ResumeSync { .. } => {
+                Err(SessionRuntimeError::UnsupportedCommand)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shadow_core_domain::AccountId;
+
+    use super::*;
+
+    #[test]
+    fn default_snapshot_is_not_configured_and_secret_free() {
+        let runtime = NoopMatrixSessionRuntime::new();
+        let snapshot = runtime.snapshot();
+
+        assert_eq!(snapshot.state, SessionState::NotConfigured);
+        assert!(snapshot.account_id.is_none());
+        assert!(snapshot.session_id.is_none());
+        assert!(snapshot.capabilities.is_empty());
+    }
+
+    #[test]
+    fn restore_session_activates_snapshot_without_network() {
+        let mut runtime = NoopMatrixSessionRuntime::new();
+
+        let event = runtime
+            .handle_command(SessionCommand::RestoreSession {
+                account_id: AccountId("@alice:example.org".to_owned()),
+            })
+            .expect("restore skeleton should be deterministic");
+        let snapshot = runtime.snapshot();
+
+        assert_eq!(event, SessionEvent::RestoreCompleted);
+        assert_eq!(snapshot.state, SessionState::Active);
+        assert_eq!(
+            snapshot.account_id,
+            Some(AccountId("@alice:example.org".to_owned()))
+        );
+        assert!(snapshot
+            .capabilities
+            .contains(&SessionCapability::RoomListAvailable));
+        assert!(snapshot
+            .capabilities
+            .contains(&SessionCapability::TimelineAvailable));
+    }
+
+    #[test]
+    fn sync_requires_matching_active_session() {
+        let mut runtime = NoopMatrixSessionRuntime::new();
+
+        runtime
+            .handle_command(SessionCommand::RestoreSession {
+                account_id: AccountId("@alice:example.org".to_owned()),
+            })
+            .expect("restore skeleton should be deterministic");
+
+        let err = runtime
+            .handle_command(SessionCommand::StartSync {
+                session_id: MatrixSessionId("other-session".to_owned()),
+            })
+            .expect_err("mismatched session must be rejected");
+        assert_eq!(err, SessionRuntimeError::SessionMismatch);
+
+        let session_id = runtime
+            .snapshot()
+            .session_id
+            .expect("restore should create a skeleton session id");
+        let event = runtime
+            .handle_command(SessionCommand::StartSync { session_id })
+            .expect("matching active session can enter sync state");
+
+        assert_eq!(event, SessionEvent::SyncStarted);
+        assert_eq!(runtime.snapshot().state, SessionState::Syncing);
+    }
+}

--- a/core/rust/crates/shadow_core_runtime/src/state.rs
+++ b/core/rust/crates/shadow_core_runtime/src/state.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionState {
+    NotConfigured,
+    Discovering,
+    Unauthenticated,
+    Authenticating,
+    Restoring,
+    Active,
+    Syncing,
+    Offline,
+    Expired,
+    Locked,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionEvent {
+    DiscoveryStarted,
+    DiscoveryCompleted,
+    LoginStarted,
+    LoginCompleted,
+    RestoreStarted,
+    RestoreCompleted,
+    SessionBecameActive,
+    SyncStarted,
+    SyncPaused,
+    SyncRecovered,
+    SessionExpired,
+    SessionLocked,
+    SessionFailed,
+    LoggedOut,
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@
 - `technical-design/TD-0011-shell-state-demo-data.md`
 - `technical-design/TD-0012-matrix-integration-readiness-audit.md`
 - `technical-design/TD-0013-matrix-session-contract.md`
+- `technical-design/TD-0014-rust-matrix-runtime-skeleton.md`
 
 ## Architekturentscheidungen
 - `adr/ADR-0001-monorepo.md`

--- a/docs/technical-design/TD-0014-rust-matrix-runtime-skeleton.md
+++ b/docs/technical-design/TD-0014-rust-matrix-runtime-skeleton.md
@@ -1,0 +1,104 @@
+# TD-0014 Rust Matrix Runtime Skeleton
+
+## Status
+
+Akzeptiert als minimaler Rust/Core-Skeleton-Slice. Dieser Slice baut keine echte Matrix-SDK-Live-Integration.
+
+## Ziel
+
+Das neue Crate `shadow_core_runtime` legt die Contract-Grundlage fuer eine spaetere Matrix Session Runtime. Es enthaelt nur Rust-Typen, Traits, DTOs, Commands, Events, Error-Kategorien und eine testbare No-op-Referenz.
+
+## 🦀 Rust/Core Umfang
+
+Neu im Rust-Workspace:
+
+- `crates/shadow_core_runtime`
+- `SessionState`
+- `SessionCommand`
+- `SessionEvent`
+- `SessionErrorKind`
+- `SessionRuntimeError`
+- `SessionSnapshot`
+- `SessionCapability`
+- `MatrixSessionRuntime`
+- `NoopMatrixSessionRuntime`
+
+Das Crate haengt nur an bestehenden Workspace-Dependencies und an `shadow_core_domain`. Es fuegt bewusst kein `matrix-rust-sdk` hinzu.
+
+## 🧩 Architektur
+
+`shadow_core_runtime` sitzt zwischen zukuenftigen Matrix-Adaptern und den bereits dokumentierten Mobile-/FFI-Boundaries.
+
+Die Struktur ist bewusst klein:
+
+- `command.rs`: app-eigene Session-Commands
+- `state.rs`: Session-State und Runtime-Events
+- `dto.rs`: wertbasierte Snapshot-/Capability-DTOs
+- `error.rs`: Session-Error-Kategorien und Runtime-Fehler
+- `runtime.rs`: Runtime-Trait und No-op-Skeleton
+
+`NoopMatrixSessionRuntime` ist keine produktive Runtime. Es ist eine deterministische Referenz fuer Contract-Tests.
+
+## 🔐 Session / Sicherheit
+
+`SessionSnapshot` enthaelt keine Secrets:
+
+- keine Access Tokens
+- keine Refresh Tokens
+- keine Crypto Secrets
+- keine SDK-internen Client-Handles
+
+Security-relevante Fehler bleiben explizit modelliert, z. B. `DeviceUntrusted` und `CryptoStateUnavailable`.
+
+## 🔄 Lifecycle
+
+Das Skeleton kann folgende lokale State-Uebergaenge ausdruecken:
+
+- `NotConfigured`
+- `Discovering`
+- `Authenticating`
+- `Active`
+- `Syncing`
+- `Unauthenticated`
+
+Diese Uebergaenge loesen keine Netzwerkzugriffe aus. `StartSync` prueft nur, ob die angefragte `MatrixSessionId` zur lokalen Skeleton-Session passt.
+
+## 🚫 Nicht-Ziele
+
+- keine echte Matrix-SDK-Integration
+- kein `matrix-rust-sdk` als Dependency
+- kein echter Login
+- kein echter Sync
+- keine Netzwerkzugriffe
+- keine produktive Persistenz
+- keine echten Matrix-Credentials
+- keine Crypto-/Encryption-Integration
+- keine Push Notifications
+- keine Bridge-Implementierung
+- keine Send-Pipeline
+
+## ✅ Akzeptanzkriterien
+
+- Das neue Crate ist im Rust-Workspace eingebunden.
+- Commands, States, Events und DTOs sind app-eigene Rust-Typen.
+- Es gibt ein Runtime-Trait fuer spaetere Adapter.
+- Es gibt Tests fuer initialen Snapshot, Restore-Skeleton und Session-ID-Pruefung.
+- Es gibt keine neue Matrix-SDK-Dependency.
+
+## 🧪 Validierung
+
+Fuer diesen Slice:
+
+- `cargo fmt --all --check`
+- `cargo test --workspace`
+- `git diff --check`
+
+## ⚠️ Risiken
+
+- Das Skeleton darf nicht als fertige Matrix-Runtime missverstanden werden.
+- Der No-op-Restore erzeugt nur eine lokale Skeleton-Session-ID und keine echte Session.
+- Streaming, Cancellation, FFI-Memory-Ownership und echte Error-Mappings muessen in spaeteren Slices konkretisiert werden.
+
+## Naechster sinnvoller Slice
+
+Der naechste Slice sollte die `Core Domain Contract Alignment`-Arbeit starten: Session-, Room-List- und Timeline-Domain-Modelle zwischen `core/contracts`, Rust-Crates und Mobile-Repositories angleichen, weiterhin ohne echte Matrix-SDK-Live-Anbindung.


### PR DESCRIPTION
## Zusammenfassung
- fuegt das neue Rust-Crate shadow_core_runtime als minimales Matrix Runtime Skeleton hinzu
- definiert app-eigene SessionCommand-, SessionState-, SessionEvent-, SessionError- und SessionSnapshot-Typen
- fuegt MatrixSessionRuntime und NoopMatrixSessionRuntime mit Contract-Tests hinzu
- dokumentiert Scope, Nicht-Ziele und Risiken in TD-0014

## Validierung
- core/rust: cargo fmt --all --check
- core/rust: cargo test --workspace
- git diff --check

## Nicht enthalten
- keine matrix-rust-sdk Dependency
- keine echte Matrix-SDK-Live-Anbindung
- kein Login, kein Sync, keine Netzwerkzugriffe, keine Persistenz und keine echten Credentials