### PR TITLE
Add FFI DTO surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Matrix-Integration-Readiness-Audit fuer Mobile-, Rust-, FFI-, Repository- und Demo-Data-Grenzen.
 - Matrix Session Contract fuer Session-/Client-Lifecycle, Commands, Events, Errors und FFI-/DTO-Grenzen.
 - Rust Matrix Runtime Skeleton mit app-eigenen Session-Commands, States, Events, DTOs, Errors und No-op-Tests.
+- FFI-/DTO-Surface fuer Session Snapshot, Commands, States, Events, Errors und Capabilities im Rust Runtime Crate.
 
 ### Changed
 

--- a/core/rust/crates/shadow_core_runtime/src/ffi.rs
+++ b/core/rust/crates/shadow_core_runtime/src/ffi.rs
@@ -1,0 +1,399 @@
+use serde::{Deserialize, Serialize};
+use shadow_core_domain::AccountId;
+
+use crate::{
+    command::SessionCommand,
+    dto::{DeviceId, HomeserverUrl, MatrixSessionId, SessionCapability, SessionSnapshot},
+    error::SessionErrorKind,
+    state::{SessionEvent, SessionState},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FfiSessionSnapshot {
+    pub account_id: Option<String>,
+    pub session_id: Option<String>,
+    pub state: FfiSessionState,
+    pub homeserver: Option<String>,
+    pub user_display_name: Option<String>,
+    pub device_id: Option<String>,
+    pub capabilities: Vec<FfiSessionCapability>,
+    pub last_sync_label: Option<String>,
+    pub error: Option<FfiSessionErrorKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FfiSessionCommand {
+    DiscoverServer { server_hint: String },
+    BeginLogin { auth_hint: Option<String> },
+    CompleteLogin { callback_payload: String },
+    RestoreSession { account_id: String },
+    StartSync { session_id: String },
+    PauseSync { session_id: String },
+    ResumeSync { session_id: String },
+    Logout { session_id: String },
+    ClearLocalSession { account_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FfiSessionState {
+    NotConfigured,
+    Discovering,
+    Unauthenticated,
+    Authenticating,
+    Restoring,
+    Active,
+    Syncing,
+    Offline,
+    Expired,
+    Locked,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FfiSessionEvent {
+    DiscoveryStarted,
+    DiscoveryCompleted,
+    LoginStarted,
+    LoginCompleted,
+    RestoreStarted,
+    RestoreCompleted,
+    SessionBecameActive,
+    SyncStarted,
+    SyncPaused,
+    SyncRecovered,
+    SessionExpired,
+    SessionLocked,
+    SessionFailed,
+    LoggedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FfiSessionErrorKind {
+    NetworkUnavailable,
+    ServerDiscoveryFailed,
+    AuthenticationRequired,
+    AuthenticationExpired,
+    RestoreFailed,
+    DeviceUntrusted,
+    CryptoStateUnavailable,
+    SyncUnavailable,
+    RateLimited,
+    ServerRejected,
+    StorageUnavailable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FfiSessionCapability {
+    RoomListAvailable,
+    TimelineAvailable,
+    SendAvailable,
+    MediaAvailable,
+    PushAvailable,
+    EncryptionAvailable,
+}
+
+impl From<SessionSnapshot> for FfiSessionSnapshot {
+    fn from(value: SessionSnapshot) -> Self {
+        Self {
+            account_id: value.account_id.map(|id| id.0),
+            session_id: value.session_id.map(|id| id.0),
+            state: value.state.into(),
+            homeserver: value.homeserver.map(|url| url.0),
+            user_display_name: value.user_display_name,
+            device_id: value.device_id.map(|id| id.0),
+            capabilities: value
+                .capabilities
+                .into_iter()
+                .map(FfiSessionCapability::from)
+                .collect(),
+            last_sync_label: value.last_sync_label,
+            error: value.error.map(FfiSessionErrorKind::from),
+        }
+    }
+}
+
+impl From<FfiSessionSnapshot> for SessionSnapshot {
+    fn from(value: FfiSessionSnapshot) -> Self {
+        Self {
+            account_id: value.account_id.map(AccountId),
+            session_id: value.session_id.map(MatrixSessionId),
+            state: value.state.into(),
+            homeserver: value.homeserver.map(HomeserverUrl),
+            user_display_name: value.user_display_name,
+            device_id: value.device_id.map(DeviceId),
+            capabilities: value
+                .capabilities
+                .into_iter()
+                .map(SessionCapability::from)
+                .collect(),
+            last_sync_label: value.last_sync_label,
+            error: value.error.map(SessionErrorKind::from),
+        }
+    }
+}
+
+impl From<SessionCommand> for FfiSessionCommand {
+    fn from(value: SessionCommand) -> Self {
+        match value {
+            SessionCommand::DiscoverServer { server_hint } => Self::DiscoverServer { server_hint },
+            SessionCommand::BeginLogin { auth_hint } => Self::BeginLogin { auth_hint },
+            SessionCommand::CompleteLogin { callback_payload } => {
+                Self::CompleteLogin { callback_payload }
+            }
+            SessionCommand::RestoreSession { account_id } => Self::RestoreSession {
+                account_id: account_id.0,
+            },
+            SessionCommand::StartSync { session_id } => Self::StartSync {
+                session_id: session_id.0,
+            },
+            SessionCommand::PauseSync { session_id } => Self::PauseSync {
+                session_id: session_id.0,
+            },
+            SessionCommand::ResumeSync { session_id } => Self::ResumeSync {
+                session_id: session_id.0,
+            },
+            SessionCommand::Logout { session_id } => Self::Logout {
+                session_id: session_id.0,
+            },
+            SessionCommand::ClearLocalSession { account_id } => Self::ClearLocalSession {
+                account_id: account_id.0,
+            },
+        }
+    }
+}
+
+impl From<FfiSessionCommand> for SessionCommand {
+    fn from(value: FfiSessionCommand) -> Self {
+        match value {
+            FfiSessionCommand::DiscoverServer { server_hint } => {
+                Self::DiscoverServer { server_hint }
+            }
+            FfiSessionCommand::BeginLogin { auth_hint } => Self::BeginLogin { auth_hint },
+            FfiSessionCommand::CompleteLogin { callback_payload } => {
+                Self::CompleteLogin { callback_payload }
+            }
+            FfiSessionCommand::RestoreSession { account_id } => Self::RestoreSession {
+                account_id: AccountId(account_id),
+            },
+            FfiSessionCommand::StartSync { session_id } => Self::StartSync {
+                session_id: MatrixSessionId(session_id),
+            },
+            FfiSessionCommand::PauseSync { session_id } => Self::PauseSync {
+                session_id: MatrixSessionId(session_id),
+            },
+            FfiSessionCommand::ResumeSync { session_id } => Self::ResumeSync {
+                session_id: MatrixSessionId(session_id),
+            },
+            FfiSessionCommand::Logout { session_id } => Self::Logout {
+                session_id: MatrixSessionId(session_id),
+            },
+            FfiSessionCommand::ClearLocalSession { account_id } => Self::ClearLocalSession {
+                account_id: AccountId(account_id),
+            },
+        }
+    }
+}
+
+impl From<SessionState> for FfiSessionState {
+    fn from(value: SessionState) -> Self {
+        match value {
+            SessionState::NotConfigured => Self::NotConfigured,
+            SessionState::Discovering => Self::Discovering,
+            SessionState::Unauthenticated => Self::Unauthenticated,
+            SessionState::Authenticating => Self::Authenticating,
+            SessionState::Restoring => Self::Restoring,
+            SessionState::Active => Self::Active,
+            SessionState::Syncing => Self::Syncing,
+            SessionState::Offline => Self::Offline,
+            SessionState::Expired => Self::Expired,
+            SessionState::Locked => Self::Locked,
+            SessionState::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<FfiSessionState> for SessionState {
+    fn from(value: FfiSessionState) -> Self {
+        match value {
+            FfiSessionState::NotConfigured => Self::NotConfigured,
+            FfiSessionState::Discovering => Self::Discovering,
+            FfiSessionState::Unauthenticated => Self::Unauthenticated,
+            FfiSessionState::Authenticating => Self::Authenticating,
+            FfiSessionState::Restoring => Self::Restoring,
+            FfiSessionState::Active => Self::Active,
+            FfiSessionState::Syncing => Self::Syncing,
+            FfiSessionState::Offline => Self::Offline,
+            FfiSessionState::Expired => Self::Expired,
+            FfiSessionState::Locked => Self::Locked,
+            FfiSessionState::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<SessionEvent> for FfiSessionEvent {
+    fn from(value: SessionEvent) -> Self {
+        match value {
+            SessionEvent::DiscoveryStarted => Self::DiscoveryStarted,
+            SessionEvent::DiscoveryCompleted => Self::DiscoveryCompleted,
+            SessionEvent::LoginStarted => Self::LoginStarted,
+            SessionEvent::LoginCompleted => Self::LoginCompleted,
+            SessionEvent::RestoreStarted => Self::RestoreStarted,
+            SessionEvent::RestoreCompleted => Self::RestoreCompleted,
+            SessionEvent::SessionBecameActive => Self::SessionBecameActive,
+            SessionEvent::SyncStarted => Self::SyncStarted,
+            SessionEvent::SyncPaused => Self::SyncPaused,
+            SessionEvent::SyncRecovered => Self::SyncRecovered,
+            SessionEvent::SessionExpired => Self::SessionExpired,
+            SessionEvent::SessionLocked => Self::SessionLocked,
+            SessionEvent::SessionFailed => Self::SessionFailed,
+            SessionEvent::LoggedOut => Self::LoggedOut,
+        }
+    }
+}
+
+impl From<FfiSessionEvent> for SessionEvent {
+    fn from(value: FfiSessionEvent) -> Self {
+        match value {
+            FfiSessionEvent::DiscoveryStarted => Self::DiscoveryStarted,
+            FfiSessionEvent::DiscoveryCompleted => Self::DiscoveryCompleted,
+            FfiSessionEvent::LoginStarted => Self::LoginStarted,
+            FfiSessionEvent::LoginCompleted => Self::LoginCompleted,
+            FfiSessionEvent::RestoreStarted => Self::RestoreStarted,
+            FfiSessionEvent::RestoreCompleted => Self::RestoreCompleted,
+            FfiSessionEvent::SessionBecameActive => Self::SessionBecameActive,
+            FfiSessionEvent::SyncStarted => Self::SyncStarted,
+            FfiSessionEvent::SyncPaused => Self::SyncPaused,
+            FfiSessionEvent::SyncRecovered => Self::SyncRecovered,
+            FfiSessionEvent::SessionExpired => Self::SessionExpired,
+            FfiSessionEvent::SessionLocked => Self::SessionLocked,
+            FfiSessionEvent::SessionFailed => Self::SessionFailed,
+            FfiSessionEvent::LoggedOut => Self::LoggedOut,
+        }
+    }
+}
+
+impl From<SessionErrorKind> for FfiSessionErrorKind {
+    fn from(value: SessionErrorKind) -> Self {
+        match value {
+            SessionErrorKind::NetworkUnavailable => Self::NetworkUnavailable,
+            SessionErrorKind::ServerDiscoveryFailed => Self::ServerDiscoveryFailed,
+            SessionErrorKind::AuthenticationRequired => Self::AuthenticationRequired,
+            SessionErrorKind::AuthenticationExpired => Self::AuthenticationExpired,
+            SessionErrorKind::RestoreFailed => Self::RestoreFailed,
+            SessionErrorKind::DeviceUntrusted => Self::DeviceUntrusted,
+            SessionErrorKind::CryptoStateUnavailable => Self::CryptoStateUnavailable,
+            SessionErrorKind::SyncUnavailable => Self::SyncUnavailable,
+            SessionErrorKind::RateLimited => Self::RateLimited,
+            SessionErrorKind::ServerRejected => Self::ServerRejected,
+            SessionErrorKind::StorageUnavailable => Self::StorageUnavailable,
+            SessionErrorKind::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<FfiSessionErrorKind> for SessionErrorKind {
+    fn from(value: FfiSessionErrorKind) -> Self {
+        match value {
+            FfiSessionErrorKind::NetworkUnavailable => Self::NetworkUnavailable,
+            FfiSessionErrorKind::ServerDiscoveryFailed => Self::ServerDiscoveryFailed,
+            FfiSessionErrorKind::AuthenticationRequired => Self::AuthenticationRequired,
+            FfiSessionErrorKind::AuthenticationExpired => Self::AuthenticationExpired,
+            FfiSessionErrorKind::RestoreFailed => Self::RestoreFailed,
+            FfiSessionErrorKind::DeviceUntrusted => Self::DeviceUntrusted,
+            FfiSessionErrorKind::CryptoStateUnavailable => Self::CryptoStateUnavailable,
+            FfiSessionErrorKind::SyncUnavailable => Self::SyncUnavailable,
+            FfiSessionErrorKind::RateLimited => Self::RateLimited,
+            FfiSessionErrorKind::ServerRejected => Self::ServerRejected,
+            FfiSessionErrorKind::StorageUnavailable => Self::StorageUnavailable,
+            FfiSessionErrorKind::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<SessionCapability> for FfiSessionCapability {
+    fn from(value: SessionCapability) -> Self {
+        match value {
+            SessionCapability::RoomListAvailable => Self::RoomListAvailable,
+            SessionCapability::TimelineAvailable => Self::TimelineAvailable,
+            SessionCapability::SendAvailable => Self::SendAvailable,
+            SessionCapability::MediaAvailable => Self::MediaAvailable,
+            SessionCapability::PushAvailable => Self::PushAvailable,
+            SessionCapability::EncryptionAvailable => Self::EncryptionAvailable,
+        }
+    }
+}
+
+impl From<FfiSessionCapability> for SessionCapability {
+    fn from(value: FfiSessionCapability) -> Self {
+        match value {
+            FfiSessionCapability::RoomListAvailable => Self::RoomListAvailable,
+            FfiSessionCapability::TimelineAvailable => Self::TimelineAvailable,
+            FfiSessionCapability::SendAvailable => Self::SendAvailable,
+            FfiSessionCapability::MediaAvailable => Self::MediaAvailable,
+            FfiSessionCapability::PushAvailable => Self::PushAvailable,
+            FfiSessionCapability::EncryptionAvailable => Self::EncryptionAvailable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_mapping_is_value_based_and_secret_free() {
+        let snapshot = SessionSnapshot {
+            account_id: Some(AccountId("@alice:example.org".to_owned())),
+            session_id: Some(MatrixSessionId("session-1".to_owned())),
+            state: SessionState::Active,
+            homeserver: Some(HomeserverUrl("https://matrix.example.org".to_owned())),
+            user_display_name: Some("Alice".to_owned()),
+            device_id: Some(DeviceId("DEVICEID".to_owned())),
+            capabilities: vec![
+                SessionCapability::RoomListAvailable,
+                SessionCapability::TimelineAvailable,
+            ],
+            last_sync_label: Some("just now".to_owned()),
+            error: None,
+        };
+
+        let ffi = FfiSessionSnapshot::from(snapshot);
+
+        assert_eq!(ffi.account_id.as_deref(), Some("@alice:example.org"));
+        assert_eq!(ffi.session_id.as_deref(), Some("session-1"));
+        assert_eq!(ffi.state, FfiSessionState::Active);
+        assert_eq!(
+            ffi.capabilities,
+            vec![
+                FfiSessionCapability::RoomListAvailable,
+                FfiSessionCapability::TimelineAvailable,
+            ]
+        );
+    }
+
+    #[test]
+    fn command_mapping_preserves_string_payloads() {
+        let ffi = FfiSessionCommand::RestoreSession {
+            account_id: "@alice:example.org".to_owned(),
+        };
+
+        let command = SessionCommand::from(ffi);
+
+        assert_eq!(
+            command,
+            SessionCommand::RestoreSession {
+                account_id: AccountId("@alice:example.org".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn error_mapping_keeps_security_relevant_categories_explicit() {
+        let ffi = FfiSessionErrorKind::from(SessionErrorKind::DeviceUntrusted);
+        let core = SessionErrorKind::from(ffi.clone());
+
+        assert_eq!(ffi, FfiSessionErrorKind::DeviceUntrusted);
+        assert_eq!(core, SessionErrorKind::DeviceUntrusted);
+    }
+}

--- a/core/rust/crates/shadow_core_runtime/src/lib.rs
+++ b/core/rust/crates/shadow_core_runtime/src/lib.rs
@@ -6,11 +6,16 @@
 pub mod command;
 pub mod dto;
 pub mod error;
+pub mod ffi;
 pub mod runtime;
 pub mod state;
 
 pub use command::SessionCommand;
 pub use dto::{DeviceId, HomeserverUrl, MatrixSessionId, SessionCapability, SessionSnapshot};
 pub use error::{SessionErrorKind, SessionRuntimeError};
+pub use ffi::{
+    FfiSessionCapability, FfiSessionCommand, FfiSessionErrorKind, FfiSessionEvent,
+    FfiSessionSnapshot, FfiSessionState,
+};
 pub use runtime::{MatrixSessionRuntime, NoopMatrixSessionRuntime};
 pub use state::{SessionEvent, SessionState};

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
 - `technical-design/TD-0012-matrix-integration-readiness-audit.md`
 - `technical-design/TD-0013-matrix-session-contract.md`
 - `technical-design/TD-0014-rust-matrix-runtime-skeleton.md`
+- `technical-design/TD-0015-ffi-dto-surface.md`
 
 ## Architekturentscheidungen
 - `adr/ADR-0001-monorepo.md`

--- a/docs/technical-design/TD-0015-ffi-dto-surface.md
+++ b/docs/technical-design/TD-0015-ffi-dto-surface.md
@@ -1,0 +1,102 @@
+# TD-0015 FFI DTO Surface
+
+## Status
+
+Akzeptiert als vorbereitender Rust/Core-Slice. Dieser Slice definiert eine FFI-/DTO-Surface, erzeugt aber keine Android-/iOS-Bindings.
+
+## Ziel
+
+Die FFI-/DTO-Surface macht Session State, Session Error, Session Snapshot und Session Command fuer spaetere mobile Bindings stabiler. Sie bleibt Rust-seitig und mappt zwischen internen `shadow_core_runtime`-Typen und stringnahen DTO-Typen.
+
+## 🔗 FFI/DTO Boundary
+
+Neu im Crate `shadow_core_runtime`:
+
+- `FfiSessionSnapshot`
+- `FfiSessionCommand`
+- `FfiSessionState`
+- `FfiSessionEvent`
+- `FfiSessionErrorKind`
+- `FfiSessionCapability`
+
+Diese Typen liegen in `src/ffi.rs` und werden aus `lib.rs` exportiert. Sie sind wertbasiert, `serde`-serialisierbar und enthalten keine Matrix-SDK-Handles.
+
+## 🦀 Rust/Core Mapping
+
+Die DTO-Surface mappt explizit:
+
+- `SessionSnapshot` <-> `FfiSessionSnapshot`
+- `SessionCommand` <-> `FfiSessionCommand`
+- `SessionState` <-> `FfiSessionState`
+- `SessionEvent` <-> `FfiSessionEvent`
+- `SessionErrorKind` <-> `FfiSessionErrorKind`
+- `SessionCapability` <-> `FfiSessionCapability`
+
+IDs und URLs werden an der FFI-Grenze als `String` transportiert:
+
+- `AccountId`
+- `MatrixSessionId`
+- `HomeserverUrl`
+- `DeviceId`
+
+Damit bleibt die mobile Seite frei von Rust-Newtype-Details, ohne die internen Core-Typen aufzugeben.
+
+## 🔄 Datenfluss
+
+```text
+Mobile Binding
+  -> FfiSessionCommand
+  -> SessionCommand
+  -> MatrixSessionRuntime
+  -> SessionSnapshot / SessionEvent
+  -> FfiSessionSnapshot / FfiSessionEvent
+  -> Mobile Binding
+```
+
+Aktuell endet der Datenfluss weiterhin im `NoopMatrixSessionRuntime`. Es gibt keine echte Matrix-SDK-Live-Anbindung.
+
+## 🚫 Nicht-Ziele
+
+- keine echte Matrix-SDK-Integration
+- keine Android-/iOS-Binding-Generierung
+- kein echter Login
+- kein echter Sync
+- keine Netzwerkzugriffe
+- keine produktive Persistenz
+- keine echten Matrix-Credentials
+- keine Crypto-/Encryption-Integration
+- keine Push Notifications
+- keine Bridge-Implementierung
+- keine Send-Pipeline
+
+## ✅ Akzeptanzkriterien
+
+- FFI-DTOs sind vom internen Runtime-Modell getrennt.
+- Mapping ist explizit und testbar.
+- DTOs enthalten keine Secrets und keine SDK-internen Handles.
+- Security-relevante Fehler wie `DeviceUntrusted` bleiben sichtbar.
+- Es wird keine neue Matrix-SDK-Dependency eingefuehrt.
+
+## 🧪 Validierung
+
+Fuer diesen Slice:
+
+- `cargo fmt --all --check`
+- `cargo test --workspace`
+- `git diff --check`
+
+Neue Tests pruefen:
+
+- Snapshot-Mapping bleibt wertbasiert.
+- Command-Mapping erhaelt String-Payloads.
+- Security-relevante Error-Kategorien bleiben explizit.
+
+## ⚠️ Risiken
+
+- Die DTOs sind noch keine stabil generierten Bindings fuer Swift/Kotlin.
+- Enum-Namen muessen vor einer Binding-Generator-Entscheidung erneut gegen Generator-Konventionen geprueft werden.
+- Streaming, Cancellation und Memory Ownership sind weiterhin eigene FFI-Slices.
+
+## Naechster sinnvoller Slice
+
+Der naechste Slice sollte die Binding-Generator-Entscheidung dokumentieren oder einen kleinen FFI-Shape-Prototyp ohne generierte produktive Bindings vorbereiten.


### PR DESCRIPTION
## Zusammenfassung
- fuegt im Rust Runtime Crate eine explizite FFI-/DTO-Surface fuer Session Snapshot, Commands, States, Events, Errors und Capabilities hinzu
- mappt bidirektional zwischen internen shadow_core_runtime-Typen und stringnahen FFI-DTOs
- dokumentiert Scope, Nicht-Ziele, Mapping und Risiken in TD-0015

## Validierung
- core/rust: cargo fmt --all --check
- core/rust: cargo test --workspace
- git diff --check

## Nicht enthalten
- keine Matrix-SDK-Live-Anbindung
- keine Android-/iOS-Binding-Generierung
- kein Login, kein Sync, keine Netzwerkzugriffe, keine Persistenz und keine echten Credentials