### PR TITLE
Add mobile repository swap boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Matrix Session Contract fuer Session-/Client-Lifecycle, Commands, Events, Errors und FFI-/DTO-Grenzen.
 - Rust Matrix Runtime Skeleton mit app-eigenen Session-Commands, States, Events, DTOs, Errors und No-op-Tests.
 - FFI-/DTO-Surface fuer Session Snapshot, Commands, States, Events, Errors und Capabilities im Rust Runtime Crate.
+- Mobile Repository Swap Boundary fuer Android und iOS, damit Demo-Repositories spaeter gegen FFI-backed Repositories getauscht werden koennen.
 
 ### Changed
 

--- a/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/MainActivity.kt
@@ -84,17 +84,23 @@ class MainActivity : ComponentActivity() {
         setContent {
             ShadowChatTheme {
                 val chatListViewModel: ChatListViewModel = viewModel(
-                    factory = ChatListViewModelFactory(DemoChatListRepository),
+                    factory = ChatListViewModelFactory(DemoShadowRepositoryProvider.chatListRepository),
                 )
 
-                ShadowChatAppShell(chatListViewModel = chatListViewModel)
+                ShadowChatAppShell(
+                    chatListViewModel = chatListViewModel,
+                    repositoryProvider = DemoShadowRepositoryProvider,
+                )
             }
         }
     }
 }
 
 @Composable
-private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
+private fun ShadowChatAppShell(
+    chatListViewModel: ChatListViewModel,
+    repositoryProvider: ShadowRepositoryProvider,
+) {
     var selectedTab by remember { mutableStateOf(AppTab.Chats) }
     var selectedRoomId by remember { mutableStateOf<String?>(null) }
     val motionEnabled = shadowMotionEnabled()
@@ -168,7 +174,7 @@ private fun ShadowChatAppShell(chatListViewModel: ChatListViewModel) {
                                         key = animatedRoomId,
                                         factory = RoomTimelineViewModelFactory(
                                             roomId = animatedRoomId,
-                                            repository = DemoRoomTimelineRepository,
+                                            repository = repositoryProvider.roomTimelineRepository(animatedRoomId),
                                         ),
                                     )
 

--- a/apps/android/app/src/main/java/com/shadowchat/app/ShadowRepositoryProvider.kt
+++ b/apps/android/app/src/main/java/com/shadowchat/app/ShadowRepositoryProvider.kt
@@ -1,0 +1,16 @@
+package com.shadowchat.app
+
+import com.shadowchat.features.chatlist.ChatListRepository
+import com.shadowchat.features.timeline.RoomTimelineRepository
+
+internal interface ShadowRepositoryProvider {
+    val chatListRepository: ChatListRepository
+
+    fun roomTimelineRepository(roomId: String): RoomTimelineRepository
+}
+
+internal object DemoShadowRepositoryProvider : ShadowRepositoryProvider {
+    override val chatListRepository: ChatListRepository = DemoChatListRepository
+
+    override fun roomTimelineRepository(roomId: String): RoomTimelineRepository = DemoRoomTimelineRepository
+}

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowChatRootView.swift
@@ -4,15 +4,22 @@ import ShadowRoomTimelineFeature
 import SwiftUI
 
 public struct ShadowChatRootView: View {
+    private let repositoryProvider: ShadowRepositoryProvider
+
     @StateObject private var router: ShadowChatRouter
     @StateObject private var chatListViewModel: ChatListViewModel
 
     public init() {
+        self.init(repositoryProvider: DemoShadowRepositoryProvider())
+    }
+
+    private init(repositoryProvider: ShadowRepositoryProvider) {
+        self.repositoryProvider = repositoryProvider
         let router = ShadowChatRouter()
         _router = StateObject(wrappedValue: router)
         _chatListViewModel = StateObject(
             wrappedValue: ChatListViewModel(
-                repository: DemoChatListRepository(),
+                repository: repositoryProvider.makeChatListRepository(),
                 onRoomSelected: { [weak router] roomId in
                     router?.openRoom(roomId)
                 }
@@ -29,7 +36,7 @@ public struct ShadowChatRootView: View {
                             RoomTimelineRoute(
                                 viewModel: RoomTimelineViewModel(
                                     roomId: roomId,
-                                    repository: DemoRoomTimelineRepository()
+                                    repository: repositoryProvider.makeRoomTimelineRepository(roomId: roomId)
                                 )
                             )
                         }

--- a/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowRepositoryProvider.swift
+++ b/apps/ios/Packages/Sources/ShadowChatAppShell/ShadowRepositoryProvider.swift
@@ -1,0 +1,17 @@
+import ShadowChatListFeature
+import ShadowRoomTimelineFeature
+
+protocol ShadowRepositoryProvider {
+    func makeChatListRepository() -> ChatListRepository
+    func makeRoomTimelineRepository(roomId: String) -> RoomTimelineRepository
+}
+
+struct DemoShadowRepositoryProvider: ShadowRepositoryProvider {
+    func makeChatListRepository() -> ChatListRepository {
+        DemoChatListRepository()
+    }
+
+    func makeRoomTimelineRepository(roomId: String) -> RoomTimelineRepository {
+        DemoRoomTimelineRepository()
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 - `technical-design/TD-0013-matrix-session-contract.md`
 - `technical-design/TD-0014-rust-matrix-runtime-skeleton.md`
 - `technical-design/TD-0015-ffi-dto-surface.md`
+- `technical-design/TD-0016-mobile-repository-swap-boundary.md`
 
 ## Architekturentscheidungen
 - `adr/ADR-0001-monorepo.md`

--- a/docs/technical-design/TD-0016-mobile-repository-swap-boundary.md
+++ b/docs/technical-design/TD-0016-mobile-repository-swap-boundary.md
@@ -1,0 +1,100 @@
+# TD-0016 Mobile Repository Swap Boundary
+
+## Status
+
+Akzeptiert als Mobile-Boundary-Slice. Dieser Slice bereitet den Austausch von Demo-/InMemory-Repositories gegen spaetere FFI-backed Repositories vor.
+
+## Ziel
+
+Android und iOS sollen ihre aktuellen Demo-Repositories spaeter gegen FFI-backed Session-, RoomList- und Timeline-Daten tauschen koennen, ohne Feature-Views oder ViewModels neu zu bauen.
+
+## 🧩 Architektur
+
+Die bestehenden Feature-Contracts bleiben stabil:
+
+- Android `ChatListRepository`
+- Android `RoomTimelineRepository`
+- iOS `ChatListRepository`
+- iOS `RoomTimelineRepository`
+
+Neu ist nur eine App-Shell-nahe Provider-Grenze:
+
+- Android `ShadowRepositoryProvider`
+- iOS `ShadowRepositoryProvider`
+
+Die Provider liefern heute Demo-Repositories. Spaeter kann eine FFI-backed Implementierung dieselben Feature-Repositories bereitstellen.
+
+## 🔗 Swap Boundary / FFI-Ausblick
+
+Die Swap Boundary sitzt bewusst in der App-Shell:
+
+- Feature-Module kennen keine App-Shell-Demo-Daten.
+- Feature-Module kennen keine FFI-DTOs.
+- ViewModels erhalten weiterhin nur ihre bisherigen Repository-Interfaces.
+- Die App-Shell entscheidet, welcher Provider verwendet wird.
+
+Dadurch bleibt die spaetere FFI-Integration eine Adapter-Frage und kein UI-Refactor.
+
+## 🔄 Datenfluss
+
+Aktueller Datenfluss:
+
+```text
+App Shell
+  -> DemoShadowRepositoryProvider
+  -> DemoChatListRepository / DemoRoomTimelineRepository
+  -> Feature ViewModel
+  -> Feature View
+```
+
+Spaeterer Datenfluss:
+
+```text
+App Shell
+  -> FfiShadowRepositoryProvider
+  -> FFI-backed ChatListRepository / RoomTimelineRepository
+  -> Feature ViewModel
+  -> Feature View
+```
+
+Die zweite Variante ist noch nicht implementiert.
+
+## 🚫 Nicht-Ziele
+
+- keine echte Matrix-SDK-Integration
+- keine echten FFI-Aufrufe aus Android oder iOS
+- keine Binding-Generierung
+- kein echter Login
+- kein echter Sync
+- keine Netzwerkzugriffe
+- keine produktive Persistenz
+- keine echten Matrix-Credentials
+- keine Push Notifications
+- keine Bridge-Implementierung
+- keine Send-Pipeline
+- kein UI-Redesign
+
+## ✅ Akzeptanzkriterien
+
+- Demo-Repositories werden ueber einen Provider in die App-Shell injiziert.
+- Feature-Repositories bleiben unveraendert.
+- Feature-Views und ViewModels muessen nicht wissen, ob Daten aus Demo oder spaeter aus FFI kommen.
+- Android und iOS verwenden dasselbe Boundary-Muster.
+- Es gibt keine neuen Dependencies und keine generierten Bindings.
+
+## 🧪 Validierung
+
+Fuer diesen Slice:
+
+- Android `./gradlew.bat assembleDebug`
+- Android `./gradlew.bat testDebugUnitTest`
+- Android `./gradlew.bat lint`
+- iOS `swift test`, falls lokal verfuegbar
+- Rust `cargo test --workspace`
+- `git diff --check`
+
+## ⚠️ Risiken
+
+- Die Provider-Grenze ist noch App-Shell-internal. Sobald echte FFI-backed Repositories entstehen, muss entschieden werden, ob sie im App-Modul, einem App-Service-Modul oder einem dedizierten Platform-Bridge-Modul liegen.
+- Fehler- und Session-State-Mapping ist noch nicht an Mobile-UI-States angeschlossen.
+- Live-Updates, Cancellation und Streaming bleiben eigene Slices.


### PR DESCRIPTION
## Zusammenfassung
- fuegt Android und iOS je einen App-Shell-nahen ShadowRepositoryProvider hinzu
- injiziert Demo-Repositories ueber diese Provider statt direkt in der Shell
- dokumentiert die spaetere Swap Boundary fuer FFI-backed Repositories in TD-0016

## Validierung
- apps/android: ./gradlew.bat assembleDebug --console=plain
- apps/android: ./gradlew.bat testDebugUnitTest --console=plain
- apps/android: ./gradlew.bat lint --console=plain
- core/rust: cargo fmt --all --check
- core/rust: cargo test --workspace
- git diff --check
- apps/ios/Packages: swift test lokal nicht ausfuehrbar, weil swift auf Windows nicht installiert ist

## Nicht enthalten
- keine echte FFI-Binding-Integration
- keine Matrix-SDK-Live-Anbindung
- kein Login, kein Sync, keine Netzwerkzugriffe, keine Persistenz und keine echten Credentials