### PR TITLE
Add room list adapter contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Das Format orientiert sich an "Keep a Changelog"; die Produktversion folgt `MAJO
 - Rust Matrix Runtime Skeleton mit app-eigenen Session-Commands, States, Events, DTOs, Errors und No-op-Tests.
 - FFI-/DTO-Surface fuer Session Snapshot, Commands, States, Events, Errors und Capabilities im Rust Runtime Crate.
 - Mobile Repository Swap Boundary fuer Android und iOS, damit Demo-Repositories spaeter gegen FFI-backed Repositories getauscht werden koennen.
+- Room List Adapter Contract fuer Rust/Core und Mobile-Mapping-Modelle als Vorbereitung auf spaetere Matrix Room List Integration.
 
 ### Changed
 

--- a/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListModels.kt
+++ b/apps/android/features/chatlist/src/main/java/com/shadowchat/features/chatlist/ChatListModels.kt
@@ -12,10 +12,40 @@ data class ChatListItemUi(
     val isFavorite: Boolean = false,
 )
 
+data class ChatListRoomSummary(
+    val roomId: String,
+    val displayName: String,
+    val lastMessagePreview: String = "",
+    val lastMessageSentAtLabel: String = "",
+    val unreadCount: Int,
+    val trustLevel: ChatListTrustLevel,
+    val membership: ChatListMembership,
+    val isFavorite: Boolean = false,
+    val hasUnreadMentions: Boolean = false,
+) {
+    fun toChatListItemUi(): ChatListItemUi = ChatListItemUi(
+        roomId = roomId,
+        title = displayName,
+        previewText = lastMessagePreview,
+        sentAtLabel = lastMessageSentAtLabel,
+        unreadCount = unreadCount,
+        trustLevel = trustLevel,
+        isFavorite = isFavorite,
+    )
+}
+
 enum class ChatListTrustLevel {
     Verified,
     Standard,
     Reduced,
+}
+
+enum class ChatListMembership {
+    Joined,
+    Invited,
+    Left,
+    Knocked,
+    Banned,
 }
 
 fun ChatListTrustLevel.toDesignTone(): ShadowTrustTone = when (this) {

--- a/apps/android/features/chatlist/src/test/java/com/shadowchat/features/chatlist/ChatListRoomSummaryMappingTest.kt
+++ b/apps/android/features/chatlist/src/test/java/com/shadowchat/features/chatlist/ChatListRoomSummaryMappingTest.kt
@@ -1,0 +1,31 @@
+package com.shadowchat.features.chatlist
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatListRoomSummaryMappingTest {
+    @Test
+    fun roomSummaryMapsToChatListItemUi() {
+        val summary = ChatListRoomSummary(
+            roomId = "sofia",
+            displayName = "Sofia Martin",
+            lastMessagePreview = "Dinner is still on.",
+            lastMessageSentAtLabel = "09:41",
+            unreadCount = 2,
+            trustLevel = ChatListTrustLevel.Verified,
+            membership = ChatListMembership.Joined,
+            isFavorite = true,
+            hasUnreadMentions = false,
+        )
+
+        val item = summary.toChatListItemUi()
+
+        assertEquals("sofia", item.roomId)
+        assertEquals("Sofia Martin", item.title)
+        assertEquals("Dinner is still on.", item.previewText)
+        assertEquals("09:41", item.sentAtLabel)
+        assertEquals(2, item.unreadCount)
+        assertEquals(ChatListTrustLevel.Verified, item.trustLevel)
+        assertEquals(true, item.isFavorite)
+    }
+}

--- a/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListModels.swift
+++ b/apps/ios/Packages/Sources/ShadowChatListFeature/ChatListModels.swift
@@ -31,6 +31,52 @@ public struct ChatListItemViewState: Equatable, Identifiable, Sendable {
     }
 }
 
+public struct ChatListRoomSummaryViewState: Equatable, Sendable {
+    public let roomId: String
+    public let displayName: String
+    public let lastMessagePreview: String
+    public let lastMessageSentAtLabel: String
+    public let unreadCount: Int
+    public let trustLevel: ChatListTrustLevel
+    public let membership: ChatListMembership
+    public let isFavorite: Bool
+    public let hasUnreadMentions: Bool
+
+    public init(
+        roomId: String,
+        displayName: String,
+        lastMessagePreview: String = "",
+        lastMessageSentAtLabel: String = "",
+        unreadCount: Int,
+        trustLevel: ChatListTrustLevel,
+        membership: ChatListMembership,
+        isFavorite: Bool = false,
+        hasUnreadMentions: Bool = false
+    ) {
+        self.roomId = roomId
+        self.displayName = displayName
+        self.lastMessagePreview = lastMessagePreview
+        self.lastMessageSentAtLabel = lastMessageSentAtLabel
+        self.unreadCount = unreadCount
+        self.trustLevel = trustLevel
+        self.membership = membership
+        self.isFavorite = isFavorite
+        self.hasUnreadMentions = hasUnreadMentions
+    }
+
+    public func asChatListItemViewState() -> ChatListItemViewState {
+        ChatListItemViewState(
+            roomId: roomId,
+            title: displayName,
+            previewText: lastMessagePreview,
+            sentAtLabel: lastMessageSentAtLabel,
+            unreadCount: unreadCount,
+            trustLevel: trustLevel,
+            isFavorite: isFavorite
+        )
+    }
+}
+
 public enum ChatListTrustLevel: Equatable, Sendable {
     case verified
     case standard
@@ -46,6 +92,14 @@ public enum ChatListTrustLevel: Equatable, Sendable {
             return .reduced
         }
     }
+}
+
+public enum ChatListMembership: Equatable, Sendable {
+    case joined
+    case invited
+    case left
+    case knocked
+    case banned
 }
 
 public enum ChatListState: Equatable, Sendable {

--- a/apps/ios/Packages/Tests/ShadowChatListFeatureTests/ChatListRoomSummaryMappingTests.swift
+++ b/apps/ios/Packages/Tests/ShadowChatListFeatureTests/ChatListRoomSummaryMappingTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import ShadowChatListFeature
+
+final class ChatListRoomSummaryMappingTests: XCTestCase {
+    func testRoomSummaryMapsToChatListItemViewState() {
+        let summary = ChatListRoomSummaryViewState(
+            roomId: "sofia",
+            displayName: "Sofia Martin",
+            lastMessagePreview: "Dinner is still on.",
+            lastMessageSentAtLabel: "09:41",
+            unreadCount: 2,
+            trustLevel: .verified,
+            membership: .joined,
+            isFavorite: true,
+            hasUnreadMentions: false
+        )
+
+        let item = summary.asChatListItemViewState()
+
+        XCTAssertEqual(item.roomId, "sofia")
+        XCTAssertEqual(item.title, "Sofia Martin")
+        XCTAssertEqual(item.previewText, "Dinner is still on.")
+        XCTAssertEqual(item.sentAtLabel, "09:41")
+        XCTAssertEqual(item.unreadCount, 2)
+        XCTAssertEqual(item.trustLevel, .verified)
+        XCTAssertTrue(item.isFavorite)
+    }
+}

--- a/core/rust/crates/shadow_core_domain/src/lib.rs
+++ b/core/rust/crates/shadow_core_domain/src/lib.rs
@@ -14,6 +14,64 @@ pub enum TrustLevel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomDisplayName(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RoomMembership {
+    Joined,
+    Invited,
+    Left,
+    Knocked,
+    Banned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomLastMessageSummary {
+    pub body: String,
+    pub sent_at_label: Option<String>,
+    pub sender_display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomUnreadState {
+    pub unread_count: u32,
+    pub has_unread_mentions: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomSummary {
+    pub room_id: RoomId,
+    pub display_name: RoomDisplayName,
+    pub last_message: Option<RoomLastMessageSummary>,
+    pub unread: RoomUnreadState,
+    pub trust_level: TrustLevel,
+    pub membership: RoomMembership,
+    pub is_favorite: bool,
+}
+
+impl RoomSummary {
+    pub fn chat_list_item(&self) -> ChatListItem {
+        ChatListItem {
+            room_id: self.room_id.clone(),
+            title: self.display_name.0.clone(),
+            unread_count: self.unread.unread_count,
+            trust_level: self.trust_level.clone(),
+        }
+    }
+}
+
+impl From<RoomSummary> for ChatListItem {
+    fn from(summary: RoomSummary) -> Self {
+        Self {
+            room_id: summary.room_id,
+            title: summary.display_name.0,
+            unread_count: summary.unread.unread_count,
+            trust_level: summary.trust_level,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChatListItem {
     pub room_id: RoomId,
     pub title: String,

--- a/core/rust/crates/shadow_core_rooms/src/lib.rs
+++ b/core/rust/crates/shadow_core_rooms/src/lib.rs
@@ -1,14 +1,149 @@
-use shadow_core_domain::{ChatListItem, RoomId, TrustLevel};
+use shadow_core_domain::{
+    ChatListItem, RoomDisplayName, RoomId, RoomLastMessageSummary, RoomMembership, RoomSummary,
+    RoomUnreadState, TrustLevel,
+};
 
-pub struct RoomListService;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoomListError {
+    Unavailable,
+}
 
-impl RoomListService {
-    pub fn bootstrap(&self) -> Vec<ChatListItem> {
-        vec![ChatListItem {
+pub trait RoomListAdapter {
+    fn load_room_summaries(&self) -> Result<Vec<RoomSummary>, RoomListError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticRoomListAdapter {
+    rooms: Vec<RoomSummary>,
+}
+
+impl StaticRoomListAdapter {
+    pub fn new(rooms: Vec<RoomSummary>) -> Self {
+        Self { rooms }
+    }
+
+    pub fn demo() -> Self {
+        Self::new(vec![RoomSummary {
             room_id: RoomId("example-room".to_owned()),
-            title: "Welcome".to_owned(),
-            unread_count: 0,
+            display_name: RoomDisplayName("Welcome".to_owned()),
+            last_message: Some(RoomLastMessageSummary {
+                body: "ShadowChat is ready for the next Room List adapter slice.".to_owned(),
+                sent_at_label: Some("Now".to_owned()),
+                sender_display_name: Some("ShadowChat".to_owned()),
+            }),
+            unread: RoomUnreadState {
+                unread_count: 0,
+                has_unread_mentions: false,
+            },
             trust_level: TrustLevel::Standard,
-        }]
+            membership: RoomMembership::Joined,
+            is_favorite: false,
+        }])
+    }
+}
+
+impl RoomListAdapter for StaticRoomListAdapter {
+    fn load_room_summaries(&self) -> Result<Vec<RoomSummary>, RoomListError> {
+        Ok(self.rooms.clone())
+    }
+}
+
+pub struct RoomListService<A: RoomListAdapter = StaticRoomListAdapter> {
+    adapter: A,
+}
+
+impl RoomListService<StaticRoomListAdapter> {
+    pub fn new() -> Self {
+        Self::with_adapter(StaticRoomListAdapter::demo())
+    }
+}
+
+impl Default for RoomListService<StaticRoomListAdapter> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A: RoomListAdapter> RoomListService<A> {
+    pub fn with_adapter(adapter: A) -> Self {
+        Self { adapter }
+    }
+
+    pub fn load_room_summaries(&self) -> Result<Vec<RoomSummary>, RoomListError> {
+        self.adapter.load_room_summaries()
+    }
+
+    pub fn bootstrap(&self) -> Vec<ChatListItem> {
+        self.load_room_summaries()
+            .unwrap_or_default()
+            .into_iter()
+            .map(ChatListItem::from)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_loads_room_summaries_from_adapter() {
+        let service =
+            RoomListService::with_adapter(StaticRoomListAdapter::new(vec![RoomSummary {
+                room_id: RoomId("sofia".to_owned()),
+                display_name: RoomDisplayName("Sofia Martin".to_owned()),
+                last_message: Some(RoomLastMessageSummary {
+                    body: "Dinner is still on.".to_owned(),
+                    sent_at_label: Some("09:41".to_owned()),
+                    sender_display_name: Some("Sofia".to_owned()),
+                }),
+                unread: RoomUnreadState {
+                    unread_count: 2,
+                    has_unread_mentions: false,
+                },
+                trust_level: TrustLevel::Verified,
+                membership: RoomMembership::Joined,
+                is_favorite: true,
+            }]));
+
+        let summaries = service.load_room_summaries().expect("summary load");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].room_id, RoomId("sofia".to_owned()));
+        assert_eq!(
+            summaries[0].display_name,
+            RoomDisplayName("Sofia Martin".to_owned())
+        );
+        assert_eq!(summaries[0].membership, RoomMembership::Joined);
+        assert_eq!(summaries[0].unread.unread_count, 2);
+    }
+
+    #[test]
+    fn bootstrap_keeps_legacy_chat_list_projection() {
+        let service =
+            RoomListService::with_adapter(StaticRoomListAdapter::new(vec![RoomSummary {
+                room_id: RoomId("design-squad".to_owned()),
+                display_name: RoomDisplayName("Design Squad".to_owned()),
+                last_message: None,
+                unread: RoomUnreadState {
+                    unread_count: 8,
+                    has_unread_mentions: true,
+                },
+                trust_level: TrustLevel::Standard,
+                membership: RoomMembership::Joined,
+                is_favorite: true,
+            }]));
+
+        let items = service.bootstrap();
+
+        assert_eq!(
+            items,
+            vec![ChatListItem {
+                room_id: RoomId("design-squad".to_owned()),
+                title: "Design Squad".to_owned(),
+                unread_count: 8,
+                trust_level: TrustLevel::Standard,
+            }]
+        );
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
 - `technical-design/TD-0014-rust-matrix-runtime-skeleton.md`
 - `technical-design/TD-0015-ffi-dto-surface.md`
 - `technical-design/TD-0016-mobile-repository-swap-boundary.md`
+- `technical-design/TD-0017-room-list-adapter-contract.md`
 
 ## Architekturentscheidungen
 - `adr/ADR-0001-monorepo.md`

--- a/docs/technical-design/TD-0017-room-list-adapter-contract.md
+++ b/docs/technical-design/TD-0017-room-list-adapter-contract.md
@@ -1,0 +1,119 @@
+# TD-0017 Room List Adapter Contract
+
+## Status
+
+Akzeptiert als Contract-/Boundary-Slice. Dieser Slice fuehrt keine Matrix-SDK-Live-Anbindung, keine FFI-Aufrufe und keine produktive Persistenz ein.
+
+## Ziel
+
+Der Room-List-Adapter-Contract beschreibt, welche app-eigenen Daten spaeter aus Matrix Room List / Sync / Sliding-Sync-Konzepten in ShadowChat einfliessen duerfen.
+
+Der Contract bleibt bewusst Matrix-nah genug fuer spaetere Adapter, aber nicht SDK-gebunden. Mobile UI und ViewModels sehen weiterhin nur stabile App-Modelle.
+
+## 🧩 Architektur
+
+Die Room List wird in drei Schichten gedacht:
+
+```text
+Matrix SDK / matrix-sdk-ui Konzepte
+  -> Rust Room List Adapter
+  -> app-eigene RoomSummary / Mobile Summary Models
+  -> ChatListRepository
+  -> ChatListViewModel
+  -> ChatList UI
+```
+
+Heute existieren nur Contract-Modelle und statische Adapter. Spaeter kann ein FFI-backed Repository dieselbe Mobile-Grenze verwenden.
+
+## 🔗 Adapter / FFI-Ausblick
+
+Rust definiert die app-eigene Basis:
+
+- `RoomSummary`
+- `RoomDisplayName`
+- `RoomLastMessageSummary`
+- `RoomUnreadState`
+- `RoomMembership`
+- `TrustLevel`
+- `RoomListAdapter`
+- `RoomListService`
+
+Android und iOS ergaenzen feature-nahe Summary-Modelle:
+
+- Android `ChatListRoomSummary`
+- Android `ChatListMembership`
+- iOS `ChatListRoomSummaryViewState`
+- iOS `ChatListMembership`
+
+Diese Modelle sind keine generierten FFI-DTOs. Sie beschreiben nur die mobile Swap-Grenze, damit spaeter FFI-backed Repositories in `ChatListItemUi` bzw. `ChatListItemViewState` mappen koennen.
+
+## 🔄 Mapping / Datenfluss
+
+Spaeteres Mapping:
+
+```text
+Matrix Room
+  -> room id
+  -> display name
+  -> latest visible message preview
+  -> unread counters / mention marker
+  -> membership state
+  -> trust / bridge-safe classification
+  -> RoomSummary
+  -> ChatListRoomSummary / ChatListRoomSummaryViewState
+  -> ChatListItemUi / ChatListItemViewState
+```
+
+Die UI bleibt absichtlich bei Chat-Listen-Modellen. Felder wie `membership` und `hasUnreadMentions` duerfen fuer zukuenftige Badges, Filter oder Warnungen vorbereitet sein, ohne heute neue Produktlogik zu aktivieren.
+
+## Contract-Felder
+
+- `roomId`: stabile app-eigene Raumkennung. Spaeter aus Matrix Room ID abgeleitet, aber nicht als SDK-Typ exponiert.
+- `displayName`: sichtbarer Raum-/Kontaktname.
+- `lastMessage`: optionale Vorschau mit Body, Zeitlabel und optionalem Sendernamen.
+- `unread`: Zaehler plus Mention-Marker.
+- `trustLevel`: `Verified`, `Standard` oder `Reduced`.
+- `membership`: `Joined`, `Invited`, `Left`, `Knocked` oder `Banned`.
+- `isFavorite`: lokaler/UI-naher Sortierhinweis, noch ohne Persistenz.
+
+## 🚫 Nicht-Ziele
+
+- keine echte Matrix-SDK-Integration
+- keine echten Matrix-Rooms
+- kein Login
+- kein Sync
+- keine Netzwerkzugriffe
+- keine produktive Persistenz
+- keine FFI-Aufrufe aus Android oder iOS
+- keine Binding-Generierung
+- keine Crypto-/Encryption-Integration
+- keine Push Notifications
+- keine Bridge-Implementierung
+- keine Send-Pipeline
+- kein UI-Redesign
+
+## ✅ Akzeptanzkriterien
+
+- Rust/Core enthaelt app-eigene Room-Summary- und Room-List-Adapter-Contracts.
+- Bestehende `ChatListItem`-Projektion bleibt fuer vorhandene Call-Sites verfuegbar.
+- Android und iOS besitzen kleine Mapping-Modelle fuer spaetere Room-Summary-Daten.
+- Mapping-Tests pruefen, dass Summary-Daten in bestehende Chat-Listen-View-States ueberfuehrt werden.
+- Keine neuen externen Dependencies werden eingefuehrt.
+
+## 🧪 Validierung
+
+Fuer diesen Slice:
+
+- Rust `cargo fmt --all --check`
+- Rust `cargo test --workspace`
+- Android `./gradlew.bat assembleDebug`
+- Android `./gradlew.bat testDebugUnitTest`
+- Android `./gradlew.bat lint`
+- iOS `swift test`, falls lokal verfuegbar
+- `git diff --check`
+
+## ⚠️ Risiken
+
+- Die Summary-Modelle sind bewusst noch Snapshot-orientiert. Streaming, Cancellation und Pagination bleiben eigene Integrationsslices.
+- Membership ist vorbereitet, aber noch nicht in der UI sichtbar. Die spaetere Produktentscheidung muss klaeren, welche Membership-Zustaende in der Chat-Liste angezeigt werden.
+- Trust-Level bleibt grob. Device Trust, Room Trust und Bridge Trust muessen in einem spaeteren Security-/Bridge-Slice genauer getrennt werden.


### PR DESCRIPTION
## Zusammenfassung
- definiert Rust/Core-Contracts fuer `RoomSummary`, `RoomMembership`, `RoomUnreadState` und `RoomListAdapter`
- ergaenzt Android/iOS Summary-Mapping-Modelle fuer spaetere FFI-backed ChatList-Repositories
- dokumentiert die Room-List-Adapter-Grenze in `TD-0017-room-list-adapter-contract.md`

## Validierung
- `cargo fmt --all --check`
- `cargo test --workspace`
- `./gradlew.bat assembleDebug`
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat lint`
- `git diff --check`

## Hinweise
- `swift test` wurde lokal versucht, ist auf Windows aber nicht verfuegbar, weil `swift` nicht installiert ist. iOS-Validierung erfolgt ueber macOS-CI.
- Keine Matrix-SDK-Live-Anbindung, keine FFI-Aufrufe und keine Netzwerk-/Persistenzlogik enthalten.