### PR TITLE
test(ios): benchmark timeline mapping and diffs

### DIFF
--- a/apps/ios/Packages/README.md
+++ b/apps/ios/Packages/README.md
@@ -20,5 +20,6 @@ Hier liegen wiederverwendbare iOS-Module wie Design, Motion, Navigation, Service
 Auf macOS mit Xcode:
 - `xcodebuild -list`
 - `xcodebuild test -scheme ShadowChatMobile -destination "platform=iOS Simulator,name=<iPhone Simulator>"`
+- `xcodebuild test -scheme ShadowChatMobile -destination "platform=iOS Simulator,name=<iPhone Simulator>" -only-testing:ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests`
 
 Auf Windows ist Swift/Xcode in der Regel nicht verfügbar; die iOS-Validierung erfolgt über macOS/Xcode oder CI.

--- a/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineCollectionAlgorithms.swift
+++ b/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineCollectionAlgorithms.swift
@@ -1,0 +1,90 @@
+public enum RoomTimelineProjection {
+    public static func map<Input, Output>(
+        _ items: [Input],
+        transform: (Input) -> Output?
+    ) -> [Output] {
+        items.compactMap(transform)
+    }
+}
+
+public enum RoomTimelineCollectionReducer {
+    public static func append<Element>(
+        _ appended: [Element],
+        to items: inout [Element]
+    ) {
+        items.append(contentsOf: appended)
+    }
+
+    public static func clear<Element>(_ items: inout [Element]) {
+        items.removeAll()
+    }
+
+    public static func insert<Element>(
+        _ item: Element,
+        at index: Int,
+        in items: inout [Element]
+    ) {
+        items.insert(item, at: max(0, min(index, items.count)))
+    }
+
+    public static func reset<Element>(
+        _ replacement: [Element],
+        in items: inout [Element]
+    ) {
+        items = replacement
+    }
+
+    public static func set<Element>(
+        _ item: Element,
+        at index: Int,
+        in items: inout [Element]
+    ) {
+        guard items.indices.contains(index) else {
+            return
+        }
+        items[index] = item
+    }
+
+    public static func truncate<Element>(
+        _ items: inout [Element],
+        to length: Int
+    ) {
+        items = Array(items.prefix(max(0, length)))
+    }
+
+    public static func popBack<Element>(_ items: inout [Element]) {
+        if !items.isEmpty {
+            items.removeLast()
+        }
+    }
+
+    public static func popFront<Element>(_ items: inout [Element]) {
+        if !items.isEmpty {
+            items.removeFirst()
+        }
+    }
+
+    public static func pushBack<Element>(
+        _ item: Element,
+        to items: inout [Element]
+    ) {
+        items.append(item)
+    }
+
+    public static func pushFront<Element>(
+        _ item: Element,
+        to items: inout [Element]
+    ) {
+        items.insert(item, at: 0)
+    }
+
+    public static func remove<Element>(
+        at index: Int,
+        from items: inout [Element]
+    ) {
+        guard items.indices.contains(index) else {
+            return
+        }
+        items.remove(at: index)
+    }
+}

--- a/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineCollectionAlgorithms.swift
+++ b/apps/ios/Packages/Sources/ShadowRoomTimelineFeature/RoomTimelineCollectionAlgorithms.swift
@@ -1,9 +1,74 @@
+import Foundation
+
+public struct RoomTimelineProjectionInput<Identifier> {
+    public let identifier: Identifier
+    public let senderDisplayName: String?
+    public let body: String
+    public let timestampMilliseconds: UInt64
+    public let direction: RoomTimelineMessageDirection
+    public let sendState: RoomTimelineProjectionSendState
+
+    public init(
+        identifier: Identifier,
+        senderDisplayName: String?,
+        body: String,
+        timestampMilliseconds: UInt64,
+        direction: RoomTimelineMessageDirection,
+        sendState: RoomTimelineProjectionSendState
+    ) {
+        self.identifier = identifier
+        self.senderDisplayName = senderDisplayName
+        self.body = body
+        self.timestampMilliseconds = timestampMilliseconds
+        self.direction = direction
+        self.sendState = sendState
+    }
+}
+
+public enum RoomTimelineProjectionSendState: Sendable {
+    case notSentYet
+    case sendingFailed
+    case sent
+    case remote
+}
+
 public enum RoomTimelineProjection {
     public static func map<Input, Output>(
         _ items: [Input],
         transform: (Input) -> Output?
     ) -> [Output] {
         items.compactMap(transform)
+    }
+
+    public static func makeItem<Identifier>(
+        _ input: RoomTimelineProjectionInput<Identifier>
+    ) -> RoomTimelineItemViewState {
+        let date = Date(
+            timeIntervalSince1970: TimeInterval(input.timestampMilliseconds) / 1_000
+        )
+        return RoomTimelineItemViewState(
+            messageId: String(describing: input.identifier),
+            senderDisplayName: input.senderDisplayName,
+            body: input.body,
+            sentAtLabel: date.formatted(date: .omitted, time: .shortened),
+            direction: input.direction,
+            deliveryState: deliveryState(for: input.sendState)
+        )
+    }
+
+    private static func deliveryState(
+        for sendState: RoomTimelineProjectionSendState
+    ) -> RoomTimelineDeliveryState {
+        switch sendState {
+        case .notSentYet:
+            .sending
+        case .sendingFailed:
+            .failed
+        case .sent:
+            .sent
+        case .remote:
+            .delivered
+        }
     }
 }
 

--- a/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelineCollectionReducerTests.swift
+++ b/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelineCollectionReducerTests.swift
@@ -10,6 +10,53 @@ final class RoomTimelineCollectionReducerTests: XCTestCase {
         XCTAssertEqual(result, ["item-2", "item-4"])
     }
 
+    func testProjectionMapsPresentationFieldsAndSendState() {
+        let input = RoomTimelineProjectionInput(
+            identifier: TestIdentifier(value: "event-1"),
+            senderDisplayName: "Ari",
+            body: "Hello",
+            timestampMilliseconds: 1_784_800_000_000,
+            direction: .outgoing,
+            sendState: .sendingFailed
+        )
+
+        let result = RoomTimelineProjection.makeItem(input)
+
+        XCTAssertEqual(result.messageId, "event-1")
+        XCTAssertEqual(result.senderDisplayName, "Ari")
+        XCTAssertEqual(result.body, "Hello")
+        XCTAssertFalse(result.sentAtLabel.isEmpty)
+        XCTAssertEqual(result.direction, .outgoing)
+        XCTAssertEqual(result.deliveryState, .failed)
+    }
+
+    func testProjectionMapsAllSendStates() {
+        let cases: [
+            (RoomTimelineProjectionSendState, RoomTimelineDeliveryState)
+        ] = [
+            (.notSentYet, .sending),
+            (.sendingFailed, .failed),
+            (.sent, .sent),
+            (.remote, .delivered)
+        ]
+
+        for (sendState, expectedDeliveryState) in cases {
+            let input = RoomTimelineProjectionInput(
+                identifier: TestIdentifier(value: "event"),
+                senderDisplayName: nil,
+                body: "Message",
+                timestampMilliseconds: 1_784_800_000_000,
+                direction: .incoming,
+                sendState: sendState
+            )
+
+            XCTAssertEqual(
+                RoomTimelineProjection.makeItem(input).deliveryState,
+                expectedDeliveryState
+            )
+        }
+    }
+
     func testReducerAppliesAllSupportedMutations() {
         var items = [1, 2, 3]
 
@@ -39,5 +86,13 @@ final class RoomTimelineCollectionReducerTests: XCTestCase {
         RoomTimelineCollectionReducer.remove(at: -1, from: &items)
 
         XCTAssertEqual(items, [1, 2, 3])
+    }
+}
+
+private struct TestIdentifier: CustomStringConvertible {
+    let value: String
+
+    var description: String {
+        value
     }
 }

--- a/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelineCollectionReducerTests.swift
+++ b/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelineCollectionReducerTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import ShadowRoomTimelineFeature
+
+final class RoomTimelineCollectionReducerTests: XCTestCase {
+    func testProjectionPreservesOrderAndDropsNilResults() {
+        let result = RoomTimelineProjection.map([1, 2, 3, 4]) { value in
+            value.isMultiple(of: 2) ? "item-\(value)" : nil
+        }
+
+        XCTAssertEqual(result, ["item-2", "item-4"])
+    }
+
+    func testReducerAppliesAllSupportedMutations() {
+        var items = [1, 2, 3]
+
+        RoomTimelineCollectionReducer.append([4, 5], to: &items)
+        RoomTimelineCollectionReducer.insert(0, at: -1, in: &items)
+        RoomTimelineCollectionReducer.set(30, at: 3, in: &items)
+        RoomTimelineCollectionReducer.remove(at: 1, from: &items)
+        RoomTimelineCollectionReducer.pushFront(-1, to: &items)
+        RoomTimelineCollectionReducer.pushBack(6, to: &items)
+        RoomTimelineCollectionReducer.popFront(&items)
+        RoomTimelineCollectionReducer.popBack(&items)
+        RoomTimelineCollectionReducer.truncate(&items, to: 4)
+
+        XCTAssertEqual(items, [0, 2, 30, 4])
+
+        RoomTimelineCollectionReducer.reset([7, 8], in: &items)
+        XCTAssertEqual(items, [7, 8])
+
+        RoomTimelineCollectionReducer.clear(&items)
+        XCTAssertTrue(items.isEmpty)
+    }
+
+    func testReducerIgnoresInvalidSetAndRemoveIndices() {
+        var items = [1, 2, 3]
+
+        RoomTimelineCollectionReducer.set(4, at: 4, in: &items)
+        RoomTimelineCollectionReducer.remove(at: -1, from: &items)
+
+        XCTAssertEqual(items, [1, 2, 3])
+    }
+}

--- a/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests.swift
+++ b/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import XCTest
+@testable import ShadowRoomTimelineFeature
+
+final class RoomTimelinePerformanceTests: XCTestCase {
+    func testTimelineMapping100ItemsPerformance() {
+        measureMapping(itemCount: 100)
+    }
+
+    func testTimelineMapping1_000ItemsPerformance() {
+        measureMapping(itemCount: 1_000)
+    }
+
+    func testTimelineMapping10_000ItemsPerformance() {
+        measureMapping(itemCount: 10_000)
+    }
+
+    func testTimelineDiffBurst100ItemsPerformance() {
+        measureDiffBurst(itemCount: 100)
+    }
+
+    func testTimelineDiffBurst1_000ItemsPerformance() {
+        measureDiffBurst(itemCount: 1_000)
+    }
+
+    func testTimelineDiffBurst10_000ItemsPerformance() {
+        measureDiffBurst(itemCount: 10_000)
+    }
+
+    private func measureMapping(itemCount: Int) {
+        let fixture = TimelinePerformanceFixture(itemCount: itemCount)
+        var mappedItems: [RoomTimelineItemViewState] = []
+
+        measure(
+            metrics: [XCTClockMetric()],
+            options: measurementOptions
+        ) {
+            mappedItems = RoomTimelineProjection.map(fixture.mappingItems) { item in
+                guard item.shouldInclude else {
+                    return nil
+                }
+                return RoomTimelineItemViewState(
+                    messageId: item.messageId,
+                    senderDisplayName: item.senderDisplayName,
+                    body: item.body,
+                    sentAtLabel: item.sentAtLabel,
+                    direction: item.direction,
+                    deliveryState: item.deliveryState
+                )
+            }
+        }
+
+        XCTAssertEqual(mappedItems.count, fixture.expectedMappedItemCount)
+    }
+
+    private func measureDiffBurst(itemCount: Int) {
+        let fixture = TimelinePerformanceFixture(itemCount: itemCount)
+        var reducedItems: [RoomTimelineItemViewState] = []
+
+        measure(
+            metrics: [XCTClockMetric()],
+            options: measurementOptions
+        ) {
+            reducedItems = fixture.baseItems
+            fixture.diffBurst.forEach {
+                $0.apply(to: &reducedItems)
+            }
+        }
+
+        XCTAssertEqual(reducedItems, fixture.resetItems)
+    }
+
+    private var measurementOptions: XCTMeasureOptions {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        return options
+    }
+}
+
+private struct TimelinePerformanceFixture {
+    let mappingItems: [TimelineMappingItem]
+    let baseItems: [RoomTimelineItemViewState]
+    let resetItems: [RoomTimelineItemViewState]
+    let diffBurst: [TimelineFixtureDiff]
+    let expectedMappedItemCount: Int
+
+    init(itemCount: Int) {
+        let mappingFixture = (0..<itemCount).map(TimelineMappingItem.init)
+        let baseFixture = (0..<itemCount).map {
+            RoomTimelineItemViewState.fixture(index: $0)
+        }
+        let resetFixture = (itemCount..<(itemCount * 2)).map {
+            RoomTimelineItemViewState.fixture(index: $0)
+        }
+
+        let mutationCount = min(itemCount, 100)
+        var burst: [TimelineFixtureDiff] = []
+        burst.reserveCapacity((mutationCount * 7) + 4)
+        for offset in 0..<mutationCount {
+            let fixtureItem = RoomTimelineItemViewState.fixture(
+                index: (itemCount * 2) + offset
+            )
+            let middleIndex = itemCount / 2
+            burst.append(.pushFront(fixtureItem))
+            burst.append(.pushBack(fixtureItem))
+            burst.append(.insert(index: middleIndex, item: fixtureItem))
+            burst.append(.set(index: middleIndex, item: fixtureItem))
+            burst.append(.remove(index: middleIndex))
+            burst.append(.popFront)
+            burst.append(.popBack)
+        }
+        burst.append(.append(Array(resetFixture.prefix(min(itemCount, 100)))))
+        burst.append(.truncate(length: itemCount))
+        burst.append(.clear)
+        burst.append(.reset(resetFixture))
+
+        mappingItems = mappingFixture
+        baseItems = baseFixture
+        resetItems = resetFixture
+        diffBurst = burst
+        expectedMappedItemCount = mappingFixture.lazy.filter(\.shouldInclude).count
+    }
+}
+
+private struct TimelineMappingItem {
+    let messageId: String
+    let senderDisplayName: String?
+    let body: String
+    let sentAtLabel: String
+    let direction: RoomTimelineMessageDirection
+    let deliveryState: RoomTimelineDeliveryState
+    let shouldInclude: Bool
+
+    init(index: Int) {
+        messageId = "message-\(index)"
+        senderDisplayName = index.isMultiple(of: 2) ? "Ari" : nil
+        body = "Deterministic message body \(index)"
+        sentAtLabel = String(format: "%02d:%02d", index % 24, index % 60)
+        direction = index.isMultiple(of: 2) ? .incoming : .outgoing
+        deliveryState = index.isMultiple(of: 3) ? .read : .delivered
+        shouldInclude = !index.isMultiple(of: 8)
+    }
+}
+
+private enum TimelineFixtureDiff {
+    case append([RoomTimelineItemViewState])
+    case clear
+    case insert(index: Int, item: RoomTimelineItemViewState)
+    case reset([RoomTimelineItemViewState])
+    case set(index: Int, item: RoomTimelineItemViewState)
+    case truncate(length: Int)
+    case popBack
+    case popFront
+    case pushBack(RoomTimelineItemViewState)
+    case pushFront(RoomTimelineItemViewState)
+    case remove(index: Int)
+
+    func apply(to items: inout [RoomTimelineItemViewState]) {
+        switch self {
+        case .append(let appended):
+            RoomTimelineCollectionReducer.append(appended, to: &items)
+        case .clear:
+            RoomTimelineCollectionReducer.clear(&items)
+        case .insert(let index, let item):
+            RoomTimelineCollectionReducer.insert(item, at: index, in: &items)
+        case .reset(let replacement):
+            RoomTimelineCollectionReducer.reset(replacement, in: &items)
+        case .set(let index, let item):
+            RoomTimelineCollectionReducer.set(item, at: index, in: &items)
+        case .truncate(let length):
+            RoomTimelineCollectionReducer.truncate(&items, to: length)
+        case .popBack:
+            RoomTimelineCollectionReducer.popBack(&items)
+        case .popFront:
+            RoomTimelineCollectionReducer.popFront(&items)
+        case .pushBack(let item):
+            RoomTimelineCollectionReducer.pushBack(item, to: &items)
+        case .pushFront(let item):
+            RoomTimelineCollectionReducer.pushFront(item, to: &items)
+        case .remove(let index):
+            RoomTimelineCollectionReducer.remove(at: index, from: &items)
+        }
+    }
+}
+
+private extension RoomTimelineItemViewState {
+    static func fixture(index: Int) -> Self {
+        .init(
+            messageId: "fixture-\(index)",
+            senderDisplayName: index.isMultiple(of: 2) ? "Ari" : "Sam",
+            body: "Fixture message \(index)",
+            sentAtLabel: "09:41",
+            direction: index.isMultiple(of: 2) ? .incoming : .outgoing,
+            deliveryState: index.isMultiple(of: 3) ? .read : .delivered
+        )
+    }
+}

--- a/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests.swift
+++ b/apps/ios/Packages/Tests/ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import XCTest
 @testable import ShadowRoomTimelineFeature
 
@@ -36,17 +35,10 @@ final class RoomTimelinePerformanceTests: XCTestCase {
             options: measurementOptions
         ) {
             mappedItems = RoomTimelineProjection.map(fixture.mappingItems) { item in
-                guard item.shouldInclude else {
+                guard let input = item.projectionInput else {
                     return nil
                 }
-                return RoomTimelineItemViewState(
-                    messageId: item.messageId,
-                    senderDisplayName: item.senderDisplayName,
-                    body: item.body,
-                    sentAtLabel: item.sentAtLabel,
-                    direction: item.direction,
-                    deliveryState: item.deliveryState
-                )
+                return RoomTimelineProjection.makeItem(input)
             }
         }
 
@@ -118,27 +110,42 @@ private struct TimelinePerformanceFixture {
         baseItems = baseFixture
         resetItems = resetFixture
         diffBurst = burst
-        expectedMappedItemCount = mappingFixture.lazy.filter(\.shouldInclude).count
+        expectedMappedItemCount = mappingFixture.lazy
+            .compactMap(\.projectionInput)
+            .count
     }
 }
 
 private struct TimelineMappingItem {
-    let messageId: String
-    let senderDisplayName: String?
-    let body: String
-    let sentAtLabel: String
-    let direction: RoomTimelineMessageDirection
-    let deliveryState: RoomTimelineDeliveryState
-    let shouldInclude: Bool
+    let projectionInput: RoomTimelineProjectionInput<TimelineFixtureIdentifier>?
 
     init(index: Int) {
-        messageId = "message-\(index)"
-        senderDisplayName = index.isMultiple(of: 2) ? "Ari" : nil
-        body = "Deterministic message body \(index)"
-        sentAtLabel = String(format: "%02d:%02d", index % 24, index % 60)
-        direction = index.isMultiple(of: 2) ? .incoming : .outgoing
-        deliveryState = index.isMultiple(of: 3) ? .read : .delivered
-        shouldInclude = !index.isMultiple(of: 8)
+        guard !index.isMultiple(of: 8) else {
+            projectionInput = nil
+            return
+        }
+        projectionInput = RoomTimelineProjectionInput(
+            identifier: TimelineFixtureIdentifier(index: index),
+            senderDisplayName: index.isMultiple(of: 2) ? "Ari" : nil,
+            body: "Deterministic message body \(index)",
+            timestampMilliseconds: 1_784_800_000_000 + UInt64(index * 1_000),
+            direction: index.isMultiple(of: 2) ? .incoming : .outgoing,
+            sendState: index.isMultiple(of: 3) ? .remote : .sent
+        )
+    }
+}
+
+private struct TimelineFixtureIdentifier: CustomStringConvertible {
+    let eventID: String
+    let transactionID: String?
+
+    init(index: Int) {
+        eventID = "$event-\(index):shadowchat.example"
+        transactionID = index.isMultiple(of: 4) ? "transaction-\(index)" : nil
+    }
+
+    var description: String {
+        transactionID ?? eventID
     }
 }
 

--- a/apps/ios/ShadowChat/Services/MatrixRustClientService+Rooms.swift
+++ b/apps/ios/ShadowChat/Services/MatrixRustClientService+Rooms.swift
@@ -311,30 +311,28 @@ extension MatrixRustClientService {
             return nil
         }
 
-        let date = Date(timeIntervalSince1970: TimeInterval(event.timestamp) / 1_000)
-        return RoomTimelineItemViewState(
-            messageId: String(describing: item.uniqueId()),
-            senderDisplayName: event.isOwn ? sessionSnapshot.account?.displayName : event.sender,
-            body: message.body,
-            sentAtLabel: date.formatted(date: .omitted, time: .shortened),
-            direction: event.isOwn ? .outgoing : .incoming,
-            deliveryState: deliveryState(for: event)
-        )
-    }
-
-    private func deliveryState(
-        for event: EventTimelineItem
-    ) -> RoomTimelineDeliveryState {
-        switch event.localSendState {
+        let sendState: RoomTimelineProjectionSendState = switch event.localSendState {
         case .notSentYet:
-            .sending
+            .notSentYet
         case .sendingFailed:
-            .failed
+            .sendingFailed
         case .sent:
             .sent
         case nil:
-            .delivered
+            .remote
         }
+        return RoomTimelineProjection.makeItem(
+            RoomTimelineProjectionInput(
+                identifier: item.uniqueId(),
+                senderDisplayName: event.isOwn
+                    ? sessionSnapshot.account?.displayName
+                    : event.sender,
+                body: message.body,
+                timestampMilliseconds: event.timestamp,
+                direction: event.isOwn ? .outgoing : .incoming,
+                sendState: sendState
+            )
+        )
     }
 
     private func roomInfo(roomID: String) async throws -> RoomInfo {

--- a/apps/ios/ShadowChat/Services/MatrixRustClientService+Rooms.swift
+++ b/apps/ios/ShadowChat/Services/MatrixRustClientService+Rooms.swift
@@ -216,7 +216,10 @@ extension MatrixRustClientService {
             roomId: roomID,
             roomTitle: context.roomTitle,
             securityState: context.securityState,
-            items: context.items.compactMap(makeTimelineItem)
+            items: RoomTimelineProjection.map(
+                context.items,
+                transform: makeTimelineItem
+            )
         )
     }
 
@@ -235,17 +238,17 @@ extension MatrixRustClientService {
     ) {
         switch diff {
         case .append(let appended):
-            items.append(contentsOf: appended)
+            RoomTimelineCollectionReducer.append(appended, to: &items)
         case .clear:
-            items.removeAll()
+            RoomTimelineCollectionReducer.clear(&items)
         case .insert(let index, let item):
-            items.insert(item, at: min(Int(index), items.count))
+            RoomTimelineCollectionReducer.insert(item, at: Int(index), in: &items)
         case .reset(let replacement):
-            items = Array(replacement)
+            RoomTimelineCollectionReducer.reset(Array(replacement), in: &items)
         case .set(let index, let item):
-            replace(item, at: Int(index), in: &items)
+            RoomTimelineCollectionReducer.set(item, at: Int(index), in: &items)
         case .truncate(let length):
-            items = Array(items.prefix(Int(length)))
+            RoomTimelineCollectionReducer.truncate(&items, to: Int(length))
         default:
             return
         }
@@ -257,40 +260,18 @@ extension MatrixRustClientService {
     ) {
         switch diff {
         case .popBack:
-            if !items.isEmpty {
-                items.removeLast()
-            }
+            RoomTimelineCollectionReducer.popBack(&items)
         case .popFront:
-            if !items.isEmpty {
-                items.removeFirst()
-            }
+            RoomTimelineCollectionReducer.popFront(&items)
         case .pushBack(let item):
-            items.append(item)
+            RoomTimelineCollectionReducer.pushBack(item, to: &items)
         case .pushFront(let item):
-            items.insert(item, at: 0)
+            RoomTimelineCollectionReducer.pushFront(item, to: &items)
         case .remove(let index):
-            removeItem(at: Int(index), from: &items)
+            RoomTimelineCollectionReducer.remove(at: Int(index), from: &items)
         default:
             return
         }
-    }
-
-    private func replace(
-        _ item: TimelineItem,
-        at index: Int,
-        in items: inout [TimelineItem]
-    ) {
-        guard items.indices.contains(index) else {
-            return
-        }
-        items[index] = item
-    }
-
-    private func removeItem(at index: Int, from items: inout [TimelineItem]) {
-        guard items.indices.contains(index) else {
-            return
-        }
-        items.remove(at: index)
     }
 
     private func makeChatListItem(_ info: RoomInfo) -> ChatListItemViewState {

--- a/docs/PROJECT-TODO.md
+++ b/docs/PROJECT-TODO.md
@@ -117,7 +117,7 @@ zu messen.
   - Scroll-Jank in Raumliste und Timeline
   - Speicher nach Öffnen mehrerer Räume
 - [x] iOS `os_signpost`-Messpunkte an Service- und Repository-Grenzen ergänzen.
-- [ ] iOS-XCTest-Performancefälle für Mapping und Timeline-Diffs ergänzen.
+- [x] iOS-XCTest-Performancefälle für Mapping und Timeline-Diffs ergänzen.
 - [ ] Android-Macrobenchmark-Modul für Start und Scrollen anlegen.
 - [ ] Android Baseline Profile für die wichtigsten Startpfade prüfen.
 - [ ] Rust-Benchmarks für DTO-Mapping und größere Snapshots ergänzen.

--- a/docs/quality/performance-baseline.md
+++ b/docs/quality/performance-baseline.md
@@ -96,7 +96,7 @@ sein. Ohne passende dSYMs gilt er nicht als belastbare Baseline.
 
 ## XCTest-Zuordnung
 
-Die noch anzulegenden Performancefälle verwenden:
+Die geplante XCTest-Zuordnung lautet:
 
 - `XCTApplicationLaunchMetric` für Cold Start
 - `XCTOSSignpostMetric` für die fünf benannten Signpost-Intervalle
@@ -104,8 +104,27 @@ Die noch anzulegenden Performancefälle verwenden:
 - `XCTMemoryMetric` für die definierte 20-Räume-Sequenz
 - `XCTClockMetric` nur für isolierte Mapping- und Diff-Fixtures
 
-Die Tests werden erst zu CI-Gates, wenn die Fixtures 100, 1.000 und 10.000
-Elemente reproduzierbar erzeugen und mehrere Geräte-Baselines stabil sind.
+Für Timeline-Mapping und Timeline-Diff-Bursts existieren deterministische
+XCTest-Fälle mit 100, 1.000 und 10.000 Elementen. Jeder Fall erfasst zehn
+Wiederholungen mit `XCTClockMetric`; XCTest führt davor einen nicht gewerteten
+Warm-up-Lauf aus. Der gemessene Code ist derselbe generische Projektions- und
+Array-Mutationspfad, den der Matrix-Adapter nutzt.
+
+Auf macOS:
+
+```bash
+cd apps/ios/Packages
+xcodebuild test \
+  -scheme ShadowChatMobile \
+  -destination "platform=iOS Simulator,name=<iPhone Simulator>" \
+  -only-testing:ShadowRoomTimelineFeatureTests/RoomTimelinePerformanceTests
+```
+
+Simulatorergebnisse dienen zunächst nur als vergleichbare
+Entwicklungscharakterisierung und werden nicht als physische
+Geräte-Runtime-Baseline ausgegeben. Die Tests werden erst zu CI-Gates, wenn
+auch die Raumlisten-Fixtures vollständig sind und mehrere Geräte-Baselines
+stabil vorliegen.
 
 ## Bekannte Hotspots
 

--- a/docs/quality/performance-baseline.md
+++ b/docs/quality/performance-baseline.md
@@ -108,7 +108,10 @@ Für Timeline-Mapping und Timeline-Diff-Bursts existieren deterministische
 XCTest-Fälle mit 100, 1.000 und 10.000 Elementen. Jeder Fall erfasst zehn
 Wiederholungen mit `XCTClockMetric`; XCTest führt davor einen nicht gewerteten
 Warm-up-Lauf aus. Der gemessene Code ist derselbe generische Projektions- und
-Array-Mutationspfad, den der Matrix-Adapter nutzt.
+Array-Mutationspfad, den der Matrix-Adapter nutzt. Der Projektionspfad umfasst
+Identifier-Konvertierung, Zeitstempelkonvertierung, lokalisierte
+Zeitformatierung und Delivery-State-Mapping. Nur die SDK-spezifische
+Event-Extraktion bleibt an der Adaptergrenze.
 
 Auf macOS:
 

--- a/docs/technical-design/TD-0018-ios-matrix-rust-runtime.md
+++ b/docs/technical-design/TD-0018-ios-matrix-rust-runtime.md
@@ -200,6 +200,14 @@ keine Account-, Raum- oder Nachrichteninhalte. Runtime-Baselines werden
 ausschließlich mit Release-Builds auf physischen Referenzgeräten erstellt;
 Debug- und Simulatorwerte bleiben Korrektheitsdiagnostik.
 
+Die generische Projektion und die Array-Mutationen für Timeline-Diffs liegen in
+`ShadowRoomTimelineFeature` und werden vom Matrix-Adapter produktiv verwendet.
+Dadurch können XCTest-Performancefälle denselben Code mit 100, 1.000 und
+10.000 app-eigenen Timeline-Modellen messen, ohne MatrixRustSDK-Typen in
+Test-Fixtures oder UI-Schichten zu veröffentlichen. Die Tests erfassen
+Charakterisierungswerte ohne CI-Schwellen; die strukturellen Kosten von
+Front-Inserts und vollständigen Snapshots bleiben Gegenstand von P0-05.
+
 Adapterinterne Listener müssen bei Raum-, Session- und Accountwechsel
 deterministisch beendet werden. Eine spätere Aufteilung des Actors darf nie
 mehr als einen Client-, Sync-, Crypto- oder Store-Owner pro Account erzeugen.


### PR DESCRIPTION
## Was geändert wurde
- produktiv genutzte Timeline-Projektion und Array-Mutationen in testbare, app-eigene Helfer extrahiert
- sechs XCTest-Performancefälle für 100, 1.000 und 10.000 Mapping-/Diff-Fixtures ergänzt
- Korrektheitstests für Projektion, Mutationen und ungültige Indizes ergänzt
- reproduzierbaren macOS-Befehl und Messgrenzen dokumentiert

## Warum
P0-03 verlangt reproduzierbare Charakterisierungswerte für die bekannten vollständigen Timeline-Mappings und linearen Diff-Operationen, bevor Optimierungen aus P0-05 bewertet werden.

## Verifikation
- git diff --check
- statische Prüfung der sechs Fälle und zehn Wiederholungen
- iOS-XCTest und App-Build laufen über CI, da Swift/Xcode lokal unter Windows nicht verfügbar sind

## Grenzen
- keine CI-Performance-Schwellen vor stabiler Geräte-Baseline
- Simulatorwerte sind Entwicklungscharakterisierung, keine physische Geräte-Runtime-Baseline
- Raumlisten-Fixtures bleiben ein separates offenes P0-03-Paket